### PR TITLE
chore: tune dependabot frontend updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,13 @@ updates:
     labels:
       - dependencies
       - javascript
+    ignore:
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@eslint/js"
+        update-types:
+          - version-update:semver-major
     groups:
       frontend-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- ignore major updates for eslint and @eslint/js in the frontend Dependabot config
- avoid grouped npm PRs that fail immediately due to current peer dependency constraints
- keep the rest of the frontend update group enabled

## Why
The current frontend dependencies PR fails at npm resolution because eslint 10 conflicts with eslint-plugin-react-hooks 7.x. This policy keeps Dependabot useful without generating a permanently broken batch PR.

## Summary by Sourcery

CI:
- Configure Dependabot to ignore major updates for eslint and @eslint/js in the frontend ecosystem while keeping the existing frontend dependency group.