### PR TITLE
chore(gitignore): ignorar lockfiles do npm e yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 tmp/
+
+package-lock.json*
+yarn.lock*


### PR DESCRIPTION
Ajusta .gitignore para ignorar lockfiles.

## Summary by Sourcery

Chores:
- Modify .gitignore to ignore npm and Yarn lockfiles.