### PR TITLE
chore: add DigitalOcean App Platform config

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,31 @@
+name: cmmg-calendar
+
+services:
+  - name: web
+    github:
+      repo: bernardopg/cmmg-calendar
+      branch: main
+      deploy_on_push: true
+    build_command: npm run build
+    run_command: npm start
+    environment_slug: node-js
+    instance_size_slug: basic-xxs
+    instance_count: 1
+    http_port: 8080
+    envs:
+      - key: NODE_ENV
+        value: "production"
+        scope: RUN_AND_BUILD_TIME
+        type: GENERAL
+      - key: HOST
+        value: "0.0.0.0"
+        scope: RUN_TIME
+        type: GENERAL
+      - key: MAX_FILE_SIZE_MB
+        value: "10"
+        scope: RUN_TIME
+        type: GENERAL
+      - key: TOTVS_TIMEOUT_MS
+        value: "30000"
+        scope: RUN_TIME
+        type: GENERAL


### PR DESCRIPTION
## Summary

- Adiciona `.do/app.yaml` para deploy no DigitalOcean App Platform
- Plano `basic-xxs` ($5/mês) — menor custo disponível
- Sem variáveis sensíveis hardcoded (autenticação TOTVS é feita pelo usuário no frontend via `/api/totvs-login`)

## Variáveis de ambiente configuradas

| Variável | Valor |
|----------|-------|
| `NODE_ENV` | `production` |
| `HOST` | `0.0.0.0` |
| `MAX_FILE_SIZE_MB` | `10` |
| `TOTVS_TIMEOUT_MS` | `30000` |

As URLs TOTVS usam os valores padrão definidos em `config.ts` (não precisam ser sobrescritas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deployment:
- Introduce DigitalOcean App Platform app configuration with a single Node.js web service, build/run commands, instance sizing, and environment variables for production deployment.