### PR TITLE
docs: rewrite README and add Dockerfile for DO deploy

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,31 @@
+name: cmmg-calendar
+
+services:
+  - name: web
+    github:
+      repo: bernardopg/cmmg-calendar
+      branch: main
+      deploy_on_push: true
+    build_command: npm run build
+    run_command: npm start
+    environment_slug: node-js
+    instance_size_slug: basic-xxs
+    instance_count: 1
+    http_port: 8080
+    envs:
+      - key: NODE_ENV
+        value: "production"
+        scope: RUN_AND_BUILD_TIME
+        type: GENERAL
+      - key: HOST
+        value: "0.0.0.0"
+        scope: RUN_TIME
+        type: GENERAL
+      - key: MAX_FILE_SIZE_MB
+        value: "10"
+        scope: RUN_TIME
+        type: GENERAL
+      - key: TOTVS_TIMEOUT_MS
+        value: "30000"
+        scope: RUN_TIME
+        type: GENERAL

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -11,6 +11,10 @@ services:
     instance_count: 1
     http_port: 8080
     envs:
+      - key: PORT
+        value: "8080"
+        scope: RUN_TIME
+        type: GENERAL
       - key: MAX_FILE_SIZE_MB
         value: "10"
         scope: RUN_TIME

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -6,21 +6,11 @@ services:
       repo: bernardopg/cmmg-calendar
       branch: main
       deploy_on_push: true
-    build_command: npm run build
-    run_command: npm start
-    environment_slug: node-js
+    dockerfile_path: Dockerfile
     instance_size_slug: basic-xxs
     instance_count: 1
     http_port: 8080
     envs:
-      - key: NODE_ENV
-        value: "production"
-        scope: RUN_AND_BUILD_TIME
-        type: GENERAL
-      - key: HOST
-        value: "0.0.0.0"
-        scope: RUN_TIME
-        type: GENERAL
       - key: MAX_FILE_SIZE_MB
         value: "10"
         scope: RUN_TIME

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ USER node
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
+ENV PORT=8080
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN npm ci --omit=dev --prefix server
 COPY --from=builder /app/server/dist/ server/dist/
 COPY --from=builder /app/react-app/dist/ react-app/dist/
 
+# Ajusta permissões e roda como usuário não-root
+RUN chown -R node:node /app
+USER node
+
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# ── Stage 1: build ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copia manifests para aproveitar cache de camadas
+COPY package*.json ./
+COPY react-app/package*.json react-app/
+COPY server/package*.json server/
+
+# Instala TODAS as dependências (incluindo devDeps para o build)
+RUN npm ci
+
+# Copia fontes e constrói
+COPY react-app/ react-app/
+COPY server/ server/
+RUN npm run build
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+# Só as dependências de produção do servidor
+COPY --from=builder /app/server/package*.json server/
+RUN npm ci --omit=dev --prefix server
+
+# Artefatos compilados
+COPY --from=builder /app/server/dist/ server/dist/
+COPY --from=builder /app/react-app/dist/ react-app/dist/
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+
+EXPOSE 8080
+
+CMD ["node", "server/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ O projeto usa um **Dockerfile multi-stage** para produção:
 ```bash
 # Build local da imagem
 docker build -t cmmg-calendar .
-docker run -p 8080:8080 -e NODE_ENV=production cmmg-calendar
+docker run -p 8080:8080 -e NODE_ENV=production -e PORT=8080 cmmg-calendar
 ```
 
 No DigitalOcean App Platform, o deploy é automático a cada push para `main`.

--- a/README.md
+++ b/README.md
@@ -1,159 +1,181 @@
-# CMMG Calendar Analyzer
+# CMMG Calendar
 
-Converte o arquivo `QuadroHorarioAluno.json` em calendários utilizáveis e oferece análise estatística por Web, API e CLI.
+> Converta seu quadro de horários do Portal do Aluno CMMG em calendário digital — Google Calendar, Thunderbird, Outlook ou qualquer app iCalendar.
 
-## Status
+[![Deploy](https://img.shields.io/badge/deploy-DigitalOcean-0080ff?logo=digitalocean&logoColor=white)](https://calendar.scalpel.com.br)
+[![Live](https://img.shields.io/website?url=https%3A%2F%2Fcalendar.scalpel.com.br&label=status&up_message=online)](https://calendar.scalpel.com.br)
+[![Node](https://img.shields.io/badge/node-%5E20.19%20%7C%7C%20%3E%3D22.12-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
+[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-- Backend principal em Node.js com Fastify + TypeScript em `server/`
-- Frontend React + TypeScript em `react-app/`
-- Deploy alvo com um único app Node servindo SPA + `/api/*`
-- Migração de Flask/Python concluída
+**🌐 Acesse em produção: [calendar.scalpel.com.br](https://calendar.scalpel.com.br)**
 
-## Principais Recursos
+---
 
-- Geração de `GoogleAgenda.csv` para importação no Google Calendar
-- Geração de `ThunderbirdAgenda.ics` para Thunderbird, Outlook, Apple Calendar e clientes iCalendar
-- Análise de registros válidos, inválidos, disciplinas, horários, locais, dias e meses
-- Interface web com três fluxos:
-  - upload manual do JSON
-  - extração automática via login no Portal do Aluno TOTVS
-  - extração manual via cookie de sessão TOTVS
-- API REST para integração
+## O que faz
 
-## Requisitos
+O portal TOTVS exporta o horário acadêmico como `QuadroHorarioAluno.json`. Esta ferramenta lê esse arquivo — ou busca diretamente via login — e gera:
+
+- **`GoogleAgenda.csv`** — importação direta no Google Calendar
+- **`Agenda.ics`** — compatível com Thunderbird, Outlook, Apple Calendar e qualquer cliente iCalendar
+
+Além disso, exibe estatísticas do semestre: disciplinas, professores, salas, distribuição por dia e mês.
+
+---
+
+## Três formas de usar
+
+### 1. Login automático _(recomendado)_
+Informe usuário e senha do Portal do Aluno. O servidor autentica no TOTVS, extrai o horário e retorna os dados — sem armazenar credenciais.
+
+### 2. Cookie manual _(avançado)_
+Cole o header `Cookie` de uma sessão ativa (`ASP.NET_SessionId` + `.ASPXAUTH`). Útil quando o login automático não estiver disponível.
+
+### 3. Upload do arquivo
+Baixe o `QuadroHorarioAluno.json` manualmente pelo portal e faça upload. Sem necessidade de login.
+
+---
+
+## Stack
+
+| Camada | Tecnologias |
+|--------|-------------|
+| Backend | Node.js · Fastify · TypeScript |
+| Frontend | React · Vite · TypeScript · CSS próprio |
+| Deploy | DigitalOcean App Platform · Docker multi-stage |
+| Testes | Node Test Runner nativo |
+
+---
+
+## Desenvolvimento local
+
+### Pré-requisitos
 
 - Node.js `^20.19.0` ou `>=22.12.0`
 - npm 10+
-- Linux, macOS ou Windows
 
-## Início Rápido
-
-### Opção 1: Web em desenvolvimento
+### Subir tudo de uma vez
 
 ```bash
 git clone https://github.com/bernardopg/cmmg-calendar.git
 cd cmmg-calendar
-npm install
-npm run dev
+npm install   # instala root + react-app + server
+npm run dev   # backend (5000) + frontend Vite (5173) em paralelo
 ```
 
-Esse comando sobe backend e frontend juntos em watch.
+| Serviço | URL |
+|---------|-----|
+| Frontend (Vite dev server) | http://localhost:5173 |
+| API | http://localhost:5000/api/health |
 
-Se preferir processos separados:
+O Vite faz proxy de `/api/*` para o Fastify local — sem CORS e sem alterar nada no código.
+
+### Processos separados
 
 ```bash
-npm run dev:server
+npm run dev:server   # apenas o Fastify (watch mode)
+npm run dev:client   # apenas o Vite
 ```
 
-```bash
-npm run dev:client
-```
+### Variáveis de ambiente
 
-O fluxo local fica assim:
+Crie `.env` na raiz (opcional — os valores abaixo já são o padrão):
 
-- Fastify em `http://localhost:5000`
-- Vite em `http://localhost:5173`
-- frontend chamando sempre `fetch('/api/...')`
-- proxy do Vite encaminhando `/api/*` para o Fastify local
-
-Abra:
-
-- Frontend: <http://localhost:5173>
-- API: <http://localhost:5000/api/health>
-
-### Variáveis de ambiente locais
-
-Crie `.env` na raiz do projeto quando precisar customizar portas, limites ou URLs do TOTVS:
-
-```bash
+```env
 PORT=5000
 HOST=0.0.0.0
 MAX_FILE_SIZE_MB=10
 TOTVS_TIMEOUT_MS=30000
-TOTVS_COOKIE=
 TOTVS_DEFAULT_ALIAS=CorporeRM
-TOTVS_QUADRO_URL=
-TOTVS_PORTAL_REFERER=
-TOTVS_LOGIN_URL=
-TOTVS_AUTO_LOGIN_URL=
-TOTVS_CONTEXT_URL=
-TOTVS_CONTEXT_SELECTION_URL=
 ```
 
-O backend também aceita `server/.env` para sobrescrever apenas valores do servidor.
+As URLs do TOTVS (`TOTVS_QUADRO_URL`, `TOTVS_LOGIN_URL`, etc.) têm valores padrão apontando para o portal da CMMG. Só precise sobrescrever se sua instituição usar uma URL diferente.
 
-### Opção 2: CLI Node
+---
+
+## CLI
+
+Para uso fora da interface web:
 
 ```bash
+# Exportar CSV e ICS a partir de um arquivo local
 npm run schedule:export -- --input data/QuadroHorarioAluno.json
-```
 
-Saída:
-
-- `output/GoogleAgenda.csv`
-- `output/ThunderbirdAgenda.ics`
-
-Outros utilitários:
-
-```bash
+# Apenas analisar (sem exportar)
 npm run schedule:analyze -- --input data/QuadroHorarioAluno.json
+
+# Buscar via cookie de sessão
 npm run totvs:fetch -- --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...'
 ```
 
-## Uso pela Interface
+Saída gerada em `output/`.
 
-1. Abra `http://localhost:5173`
-2. Escolha um fluxo:
-   - fazer login no Portal do Aluno;
-   - colar um cookie TOTVS manualmente;
-   - enviar o arquivo JSON manualmente.
-3. Revise as estatísticas
-4. Exporte CSV ou ICS
+---
 
 ## API
 
-- `GET /api/health`
-- `POST /api/analyze`
-- `POST /api/extract-analyze`
-- `POST /api/totvs-login`
+```
+GET  /api/health           → status do servidor
+POST /api/analyze          → analisa JSON enviado por upload (multipart)
+POST /api/extract-analyze  → extrai e analisa via cookie TOTVS
+POST /api/totvs-login      → autentica e extrai via usuário/senha
+```
 
-Exemplo:
+Exemplo rápido:
 
 ```bash
 curl -X POST \
-  -F "file=@data/QuadroHorarioAluno.json" \
-  http://localhost:5000/api/analyze
+  -F "file=@QuadroHorarioAluno.json" \
+  https://calendar.scalpel.com.br/api/analyze
 ```
 
-Observação:
+---
 
-- exportação CSV e ICS da interface continua client-side em `react-app/src/utils/exportUtils.ts`
+## Estrutura do projeto
 
-## Estrutura do Projeto
-
-```text
+```
 cmmg-calendar/
-├── package.json
-├── server/
-├── react-app/
-└── docs/
+├── server/          # Fastify + TypeScript (backend)
+│   └── src/
+│       ├── routes/  # endpoints da API
+│       └── services/# lógica TOTVS e análise
+├── react-app/       # React + Vite (frontend)
+│   └── src/
+│       ├── pages/
+│       └── components/
+├── Dockerfile       # build multi-stage para produção
+├── .do/app.yaml     # spec do DigitalOcean App Platform
+└── docs/            # guias detalhados
 ```
 
-Observação:
+---
 
-- `server/` é o backend principal atual.
-- o fluxo principal do projeto depende apenas de Node.js.
+## Deploy
+
+O projeto usa um **Dockerfile multi-stage** para produção:
+
+1. **Stage build** — instala todas as dependências e compila React + TypeScript
+2. **Stage runner** — copia apenas os artefatos compilados e as dependências de produção
+
+```bash
+# Build local da imagem
+docker build -t cmmg-calendar .
+docker run -p 8080:8080 -e NODE_ENV=production cmmg-calendar
+```
+
+No DigitalOcean App Platform, o deploy é automático a cada push para `main`.
+
+---
 
 ## Documentação
 
-- Visão geral: [DOCUMENTACAO.md](DOCUMENTACAO.md)
-- Índice de documentação: [docs/DOCUMENTATION_INDEX.md](docs/DOCUMENTATION_INDEX.md)
-- Instalação: [docs/guides/INSTALLATION.md](docs/guides/INSTALLATION.md)
-- Interface web: [docs/guides/WEB_INTERFACE.md](docs/guides/WEB_INTERFACE.md)
-- API: [docs/guides/API_REFERENCE.md](docs/guides/API_REFERENCE.md)
-- Migração: [docs/guides/MIGRATION_STATUS.md](docs/guides/MIGRATION_STATUS.md)
-- Google Calendar: [docs/guides/GOOGLE_CALENDAR.md](docs/guides/GOOGLE_CALENDAR.md)
-- Thunderbird: [docs/guides/THUNDERBIRD.md](docs/guides/THUNDERBIRD.md)
+- [Documentação completa](DOCUMENTACAO.md)
+- [Instalação detalhada](docs/guides/INSTALLATION.md)
+- [Interface web](docs/guides/WEB_INTERFACE.md)
+- [Referência da API](docs/guides/API_REFERENCE.md)
+- [Google Calendar](docs/guides/GOOGLE_CALENDAR.md)
+- [Thunderbird / iCalendar](docs/guides/THUNDERBIRD.md)
+
+---
 
 ## Contribuição
 
@@ -165,14 +187,8 @@ Consulte [SECURITY.md](SECURITY.md).
 
 ## Licença
 
-Este projeto está sob licença MIT. Consulte [LICENSE](LICENSE).
+MIT — consulte [LICENSE](LICENSE).
 
-## Créditos
+---
 
-Autor e mantenedor:
-
-- Bernardo Gomes
-- E-mail: <bernardo.gomes@bebitterbebetter.com.br>
-- Site: bebitterbebetter.com.br
-- Instagram/X: @be.pgomes
-- GitHub: [bernardopg](https://github.com/bernardopg)
+**Autor:** Bernardo Gomes · [bebitterbebetter.com.br](https://bebitterbebetter.com.br) · [@be.pgomes](https://instagram.com/be.pgomes) · [github.com/bernardopg](https://github.com/bernardopg)


### PR DESCRIPTION
## Summary

- Reescreve o README com URL de produção, badges, tabela de stack, os três fluxos de uso explicados, CLI, estrutura do projeto e informações de deploy
- Remove referências à migração Python (concluída) e informações desatualizadas
- Adiciona `Dockerfile` multi-stage que resolve o problema do buildpack DO prunar devDeps antes do build

## Changelog README

- Badge de status ao vivo apontando para `calendar.scalpel.com.br`
- Seção "Três formas de usar" (login, cookie, upload)
- Tabela de stack técnica
- Tabela de URLs de desenvolvimento local
- Seção de deploy com explicação do Docker multi-stage
- Variáveis de ambiente com valores padrão visíveis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Revise the README to better document the product, usage flows, local development, CLI, API, and deployment, and add containerization and DigitalOcean App Platform configuration for production deployment.

Deployment:
- Introduce a multi-stage Dockerfile for building and running the app in production and add DigitalOcean App Platform configuration for automated deploys from the main branch.

Documentation:
- Rewrite the README with clarified product description, usage modes, tech stack, local development URLs, CLI commands, API overview, project structure, and deployment instructions including environment defaults.