### PR TITLE
docs: reorganiza documentação do projeto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,117 @@
 # Guia de Contribuição
 
-Obrigado por considerar contribuir com o CMMG Calendar Analyzer.
+Obrigado por contribuir com o CMMG Calendar. Este projeto prioriza mudanças pequenas, verificáveis e bem documentadas.
 
-## Como contribuir
+## Stack Canônica
 
-1. Faça um fork do projeto.
+- Backend: `server/`, Fastify + TypeScript.
+- Frontend: `react-app/`, React + Vite + TypeScript.
+- Node: `^22.12.0` ou `>=24.0.0`.
+- npm: `>=10`.
+
+## Fluxo Recomendado
+
+1. Atualize sua branch a partir de `main`.
 2. Crie uma branch descritiva.
-3. Implemente mudanças pequenas e focadas.
-4. Atualize a documentação quando necessário.
-5. Abra um Pull Request com descrição clara.
+3. Faça uma mudança focada.
+4. Atualize documentação quando comportamento, comandos, API ou ambiente mudarem.
+5. Rode as verificações locais.
+6. Abra um Pull Request com descrição objetiva.
 
 Exemplo:
 
 ```bash
-git checkout -b feat/minha-melhoria
+git switch main
+git pull
+git switch -c feat/minha-melhoria
 ```
 
-## Padrões esperados
-
-- preserve o estilo de código existente
-- não inclua mudanças fora do escopo
-- prefira correções de causa-raiz
-- mantenha mensagens de commit objetivas
-
-## Backend
-
-Fluxo principal:
+## Instalação
 
 ```bash
 npm install
+```
+
+## Desenvolvimento
+
+Full stack:
+
+```bash
 npm run dev
+```
+
+Separado:
+
+```bash
+npm run dev:server
+npm run dev:client
+```
+
+## Verificações Antes do PR
+
+Rode tudo:
+
+```bash
+npm run check
+```
+
+Ou rode por partes:
+
+```bash
+npm run lint
 npm run test
 npm run build
 ```
 
-## Frontend
-
-Use `npm` como fluxo oficial do repositório.
+Checks mais específicos:
 
 ```bash
-npm run dev:client
-npm run lint
+npm run test --prefix server
+npm run build --prefix server
+npm run lint --prefix react-app
 npm run build --prefix react-app
 ```
 
+## Padrões de Código
+
+- Preserve o estilo existente.
+- Prefira mudanças pequenas e de causa-raiz.
+- Evite refatorações sem relação com o problema.
+- Não introduza fallback de compatibilidade sem necessidade concreta.
+- Não persista credenciais, cookies TOTVS ou dados pessoais.
+- Garanta mensagens de erro legíveis para usuário final.
+
+## Documentação
+
+Atualize documentação quando mudar:
+
+- comandos npm;
+- variáveis de ambiente;
+- endpoints da API;
+- formato de entrada ou saída;
+- fluxo da interface;
+- deploy, CI ou requisitos de versão.
+
+Arquivos principais:
+
+- `README.md`
+- `DOCUMENTACAO.md`
+- `docs/DOCUMENTATION_INDEX.md`
+- guias em `docs/guides/`
+
 ## Checklist de Pull Request
 
-- [ ] O problema foi descrito claramente
-- [ ] A solução está focada no escopo
-- [ ] A documentação foi atualizada
-- [ ] Não foram introduzidos arquivos ou links quebrados
+- [ ] Escopo do problema está claro.
+- [ ] Solução é pequena e focada.
+- [ ] Testes ou justificativa de ausência estão descritos.
+- [ ] Documentação foi atualizada quando necessário.
+- [ ] Não há links, comandos ou rotas quebradas adicionadas.
+- [ ] Não há segredos em código, logs, fixtures ou documentação.
 
-## Código de conduta
+## Segurança
+
+Se encontrar vulnerabilidade, não abra issue pública com detalhes sensíveis. Siga [SECURITY.md](SECURITY.md).
+
+## Código de Conduta
 
 Ao contribuir, siga [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
-
-## Dúvidas
-
-Abra uma issue ou consulte os canais em [CREDITS.md](CREDITS.md).

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,14 +1,18 @@
 # Créditos
 
-## Autor e mantenedor
+## Autor e Mantenedor
 
 **Bernardo Gomes**
 
 - E-mail: <bernardo.gomes@bebitterbebetter.com.br>
-- Site: bebitterbebetter.com.br[https://bebitterbebetter.com.br]
-- Instagram: @be.pgomes[https://www.instagram.com/be.pgomes]
-- GitHub: <https://github.com/bernardopg>[https://github.com/bernardopg]
+- Site: <https://bebitterbebetter.com.br>
+- Instagram: <https://www.instagram.com/be.pgomes>
+- GitHub: <https://github.com/bernardopg>
 
 ## Projeto
 
-CMMG Calendar Analyzer foi criado para facilitar a conversão e análise de horários acadêmicos com foco em usabilidade para estudantes e equipes acadêmicas.
+CMMG Calendar foi criado para facilitar a conversão e análise de horários acadêmicos do Portal do Aluno CMMG, reduzindo trabalho manual e erros ao montar calendários de aula.
+
+## Tecnologias e Ecossistema
+
+O projeto usa ferramentas open source como Node.js, Fastify, React, Vite, TypeScript e bibliotecas do ecossistema npm. Consulte `package.json`, `server/package.json` e `react-app/package.json` para a lista completa de dependências.

--- a/DOCUMENTACAO.md
+++ b/DOCUMENTACAO.md
@@ -1,38 +1,99 @@
-# Documentação Completa
+# Manual do Projeto
 
-Guia oficial de uso, execução e integração do CMMG Calendar Analyzer.
+Este é o manual central do CMMG Calendar. Ele explica o produto, os fluxos de uso, a arquitetura, os comandos e os pontos de operação que precisam estar corretos para desenvolver, manter ou integrar a aplicação.
 
-## Visão geral
+## Resumo Executivo
 
-O projeto recebe um `QuadroHorarioAluno.json` e permite:
+O CMMG Calendar converte dados do quadro de horários acadêmico do Portal do Aluno CMMG em formatos de calendário. O usuário pode autenticar no TOTVS, usar um cookie de sessão ou enviar manualmente o arquivo `QuadroHorarioAluno.json`.
 
-- analisar a grade acadêmica
-- exportar CSV compatível com Google Calendar
-- exportar ICS compatível com Thunderbird e outros clientes iCalendar
+O sistema entrega:
 
-Formas de uso disponíveis:
+- análise do semestre com totais, disciplinas, horários, locais, dias da semana e distribuição mensal;
+- `GoogleAgenda.csv` para Google Calendar;
+- `ThunderbirdAgenda.ics` para Thunderbird, Outlook, Apple Calendar e clientes iCalendar;
+- API HTTP para integração;
+- CLIs locais para análise, exportação e consulta via cookie.
 
-- interface web
-- API REST
-- CLI local
+## Estado Atual do Projeto
 
-## Arquitetura atual
+| Área | Estado canônico |
+| --- | --- |
+| Frontend | `react-app/`, React 19, Vite 8, TypeScript 6 |
+| Backend | `server/`, Fastify 5, TypeScript 6 |
+| Deploy principal | Docker multi-stage com Node 24 no DigitalOcean App Platform |
+| Testes | Node Test Runner no backend |
+| CI | GitHub Actions em Node 24 com jobs `backend` e `frontend` |
+| Migração legada | Migração Flask/Python concluída; backend atual é Node |
 
-- `server/` contém o backend atual em Fastify + TypeScript
-- o app Node serve o build do `react-app/dist` em produção
-- as rotas da API ficam sob `/api/*`
-- a exportação usada pela interface web é client-side
-- o backend também expõe utilitários CLI em Node para análise, exportação e fetch via cookie
-- `react-app/` contém o frontend React + TypeScript
+## Como o Produto Funciona
 
-## Requisitos
+### Fluxo 1: Login TOTVS
 
-- Node.js `^20.19.0` ou `>=22.12.0`
-- npm 10+
+1. Usuário informa usuário e senha do Portal do Aluno.
+2. Frontend chama `POST /api/totvs-login`.
+3. Backend autentica no TOTVS, seleciona contexto acadêmico e busca o `QuadroHorarioAluno`.
+4. Backend devolve análise e dados brutos.
+5. Frontend exibe estatísticas e permite exportar CSV ou ICS no navegador.
 
-## Instalação
+Use quando o portal estiver disponível e as credenciais forem válidas.
 
-### Desenvolvimento local em watch
+### Fluxo 2: Cookie TOTVS
+
+1. Usuário cola o header `Cookie` de uma sessão já autenticada.
+2. Frontend chama `POST /api/extract-analyze`.
+3. Backend consulta diretamente o endpoint `QuadroHorarioAluno` do TOTVS.
+4. Backend devolve análise e dados brutos.
+
+Use como alternativa avançada quando o login automático não funcionar.
+
+### Fluxo 3: Upload JSON
+
+1. Usuário envia `QuadroHorarioAluno.json`.
+2. Frontend valida o formato mínimo (`data.SHorarioAluno`).
+3. Frontend chama `POST /api/analyze` com `multipart/form-data`.
+4. Backend valida, analisa e devolve as estatísticas.
+5. Frontend exporta os arquivos usando os dados carregados no navegador.
+
+Use quando o usuário já tiver o arquivo local.
+
+## Arquitetura
+
+```text
+Browser
+  |
+  | fetch('/api/...')
+  v
+React/Vite SPA
+  |
+  | dev: proxy Vite -> http://127.0.0.1:5000
+  | prod: mesmo domínio, Fastify serve SPA + API
+  v
+Fastify API
+  |
+  | opcional: login/cookie
+  v
+TOTVS Portal Educacional
+```
+
+Componentes principais:
+
+- `react-app/src/pages/HomePage.tsx`: tela do gerador e fluxos de login, cookie e upload.
+- `react-app/src/hooks/useScheduleAnalysis.ts`: chamadas para `/api/analyze`, `/api/extract-analyze` e `/api/totvs-login`.
+- `react-app/src/utils/exportUtils.ts`: geração client-side de CSV e ICS.
+- `server/src/index.ts`: composição do Fastify, CORS, rate limit, headers, estáticos e rotas.
+- `server/src/services/totvsClient.ts`: comunicação com TOTVS.
+- `server/src/services/analyzeSchedule.ts`: cálculo das estatísticas.
+- `server/src/services/exportSchedule.ts`: exportação usada pela CLI.
+
+Detalhes estão em [docs/guides/ARCHITECTURE.md](docs/guides/ARCHITECTURE.md).
+
+## Instalação Local
+
+Requisitos:
+
+- Node.js `^22.12.0` ou `>=24.0.0`
+- npm `>=10`
+- Git
 
 ```bash
 git clone https://github.com/bernardopg/cmmg-calendar.git
@@ -41,179 +102,203 @@ npm install
 npm run dev
 ```
 
-Fluxo:
+URLs locais:
 
-- Fastify em `http://localhost:5000`
-- Vite em `http://localhost:5173`
-- proxy do Vite encaminhando `/api/*` para o servidor Fastify
-- hot reload no frontend e watch no backend via `tsx`
+- Frontend: `http://localhost:5173`
+- API: `http://localhost:5000/api/health`
 
-### Build local do app único
+Veja o passo a passo completo em [docs/guides/INSTALLATION.md](docs/guides/INSTALLATION.md).
 
-```bash
-npm run build
-npm start
+## Comandos
+
+| Comando | Uso |
+| --- | --- |
+| `npm run dev` | Desenvolvimento full stack em watch mode. |
+| `npm run dev:server` | Apenas backend. |
+| `npm run dev:client` | Apenas frontend. |
+| `npm run lint` | Lint do frontend. |
+| `npm run test` | Testes do backend. |
+| `npm run build` | Build de frontend e backend. |
+| `npm run check` | Lint, testes e build. |
+| `npm start` | Executa `server/dist/index.js`. |
+
+CLIs:
+
+| Comando | Resultado |
+| --- | --- |
+| `npm run schedule:analyze -- --input data/QuadroHorarioAluno.json` | Imprime análise no terminal. |
+| `npm run schedule:export -- --input data/QuadroHorarioAluno.json` | Gera `output/GoogleAgenda.csv` e `output/ThunderbirdAgenda.ics`. |
+| `npm run totvs:fetch -- --cookie '...'` | Salva `data/QuadroHorarioAluno.json` consultado no TOTVS. |
+
+Veja [docs/guides/CLI.md](docs/guides/CLI.md).
+
+## Variáveis de Ambiente
+
+As variáveis podem ficar em `.env` na raiz. `server/.env` também é carregado e sobrescreve valores da raiz.
+
+| Variável | Padrão | Uso |
+| --- | --- | --- |
+| `NODE_ENV` | `development` | Ambiente de execução. |
+| `HOST` | `0.0.0.0` | Host do Fastify. |
+| `PORT` | `5000` | Porta do backend local ou processo único. |
+| `MAX_FILE_SIZE_MB` | `10` | Limite de upload em MB. |
+| `TOTVS_TIMEOUT_MS` | `30000` | Timeout das chamadas ao TOTVS. |
+| `TOTVS_BASE_URL` | URL TOTVS CMMG | Base para montar endpoints TOTVS. |
+| `TOTVS_COOKIE` | vazio | Cookie padrão para fluxos via cookie e CLI. |
+| `TOTVS_QUADRO_URL` | derivado de `TOTVS_BASE_URL` | Endpoint do `QuadroHorarioAluno`. |
+| `TOTVS_PORTAL_REFERER` | derivado de `TOTVS_BASE_URL` | Referer esperado pelo portal. |
+| `TOTVS_LOGIN_URL` | derivado de `TOTVS_BASE_URL` | Tela de login do Portal do Aluno. |
+| `TOTVS_AUTO_LOGIN_URL` | derivado de `TOTVS_BASE_URL` | Endpoint de auto-login. |
+| `TOTVS_CONTEXT_URL` | derivado de `TOTVS_BASE_URL` | Endpoint de contexto acadêmico. |
+| `TOTVS_CONTEXT_SELECTION_URL` | derivado de `TOTVS_BASE_URL` | Endpoint de seleção de contexto. |
+| `TOTVS_DEFAULT_ALIAS` | `CorporeRM` | Alias preferido no login TOTVS. |
+| `CORS_ORIGINS` | vazio | Lista separada por vírgula para liberar CORS em produção. |
+| `VITE_PORT` | `5173` | Porta do Vite. |
+| `VITE_API_PROXY_TARGET` | `http://127.0.0.1:$PORT` | Destino do proxy `/api` no Vite. |
+
+## API
+
+Base local: `http://localhost:5000/api`
+
+| Método | Endpoint | Descrição |
+| --- | --- | --- |
+| `GET` | `/api/health` | Status do backend. |
+| `POST` | `/api/analyze` | Analisa arquivo JSON enviado por upload. |
+| `POST` | `/api/extract-analyze` | Consulta TOTVS por cookie e analisa. |
+| `POST` | `/api/totvs-login` | Faz login TOTVS, consulta horário e analisa. |
+
+Resposta de sucesso segue o padrão:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
 ```
 
-Esse fluxo gera:
+Resposta de erro segue o padrão:
 
-- `react-app/dist`
-- `server/dist`
-
-## Uso pela interface web
-
-Há três fluxos disponíveis na página principal:
-
-### Login TOTVS
-
-Informe usuário e senha do Portal do Aluno. O backend chama `/totvs-login`, autentica no TOTVS, busca o horário e devolve a análise.
-
-### Cookie manual
-
-Cole um cookie de sessão autenticada. O backend chama `/extract-analyze`.
-
-### Upload manual
-
-Envie o `QuadroHorarioAluno.json` diretamente. O backend chama `/analyze`.
-
-## Uso via CLI
-
-### Gerar CSV e ICS
-
-Pré-requisito:
-
-- arquivo em `data/QuadroHorarioAluno.json`
-
-Comando:
-
-```bash
-npm run schedule:export -- --input data/QuadroHorarioAluno.json
+```json
+{
+  "success": false,
+  "error": "Mensagem legível"
+}
 ```
 
-Saída:
+Contratos completos: [docs/guides/API_REFERENCE.md](docs/guides/API_REFERENCE.md).
 
-- `output/GoogleAgenda.csv`
-- `output/ThunderbirdAgenda.ics`
+## Formato do JSON de Entrada
 
-### Analisar no terminal
-
-```bash
-npm run schedule:analyze -- --input data/QuadroHorarioAluno.json
-```
-
-### Baixar JSON via cookie
-
-Há também o utilitário:
-
-```bash
-npm run totvs:fetch -- --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...'
-```
-
-Ele salva o arquivo por padrão em `data/QuadroHorarioAluno.json`.
-
-## API REST
-
-Base URL local do backend: `http://localhost:5000/api`
-
-### Endpoints disponíveis
-
-- `GET /api/health`
-- `POST /api/analyze`
-- `POST /api/extract-analyze`
-- `POST /api/totvs-login`
-
-Observação:
-
-- exportação CSV e ICS da interface web é client-side
-- a API do app Node não expõe endpoints de exportação porque a interface gera CSV e ICS localmente
-
-Detalhes completos estão em [docs/guides/API_REFERENCE.md](docs/guides/API_REFERENCE.md).
-
-## Formato do JSON de entrada
-
-Estrutura esperada:
+Estrutura mínima esperada:
 
 ```json
 {
   "data": {
     "SHorarioAluno": [
       {
-        "NOME": "Matemática",
-        "DATAINICIAL": "2025-03-10T00:00:00",
-        "DATAFINAL": "2025-03-10T00:00:00",
+        "NOME": "Anatomia",
+        "DATAINICIAL": "2026-03-10T00:00:00",
+        "DATAFINAL": "2026-03-10T00:00:00",
         "HORAINICIAL": "08:00:00",
         "HORAFINAL": "10:00:00",
+        "DIASEMANA": "2",
         "PREDIO": "Campus",
         "BLOCO": "A",
         "SALA": "101",
-        "CODTURMA": "MAT01",
-        "DIASEMANA": "1"
+        "CODTURMA": "MED01",
+        "CODSUBTURMA": "A",
+        "NOMEREDUZIDO": "ANA",
+        "URLAULAONLINE": "https://exemplo.invalid/aula"
       }
     ]
   }
 }
 ```
 
-Campos mais relevantes:
+Campos mínimos para análise válida:
 
 - `NOME`
 - `DATAINICIAL`
-- `DATAFINAL`
+
+Campos mínimos para evento ICS:
+
+- `NOME`
+- `DATAINICIAL`
 - `HORAINICIAL`
 - `HORAFINAL`
+
+Campos usados para descrição e localização:
+
 - `PREDIO`, `BLOCO`, `SALA`
 - `CODTURMA`, `CODSUBTURMA`, `NOMEREDUZIDO`, `URLAULAONLINE`
 
-## Arquivos de saída
+## Exportação
 
 ### CSV
 
-- nome padrão: `GoogleAgenda.csv`
-- datas em formato `MM/DD/YYYY`
-- compatível com importação do Google Calendar
+- Nome padrão: `GoogleAgenda.csv`
+- Formato de data: `MM/DD/YYYY`
+- Campos principais: assunto, data/hora inicial, data/hora final, descrição, local e privacidade.
+- Uso principal: importação no Google Calendar.
 
 ### ICS
 
-- nome padrão: `ThunderbirdAgenda.ics`
-- formato `VCALENDAR` + `VEVENT`
-- inclui `UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `SUMMARY`, `DESCRIPTION` e `LOCATION`
+- Nome padrão: `ThunderbirdAgenda.ics`
+- Formato: `VCALENDAR` com múltiplos `VEVENT`.
+- Inclui `UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `SUMMARY`, `DESCRIPTION`, `LOCATION`, `STATUS` e `TRANSP`.
+- Uso principal: Thunderbird, Outlook, Apple Calendar e clientes iCalendar.
 
-## Solução de problemas
+## Segurança e Privacidade
 
-### Arquivo inválido na análise
+- A aplicação não grava credenciais TOTVS em banco de dados.
+- Senhas e cookies são usados apenas para consultar o portal durante a requisição.
+- Logs do backend redigem `cookie`, `authorization`, `password` e `totvs_cookie`.
+- Uploads são limitados por tamanho.
+- Rotas com maior custo têm rate limit.
+- Em produção, CORS cross-origin é bloqueado por padrão e só é liberado via `CORS_ORIGINS`.
 
-Verifique:
+## Deploy
 
-- se o arquivo é JSON válido
-- se `data` contém a chave `SHorarioAluno`
-- se os registros possuem ao menos `NOME` e `DATAINICIAL`
+O deploy principal usa `Dockerfile` multi-stage:
 
-### Frontend sem conexão com a API
+1. `builder`: instala dependências e executa `npm run build`.
+2. `runner`: instala dependências de produção do servidor, copia `server/dist` e `react-app/dist`, roda como usuário `node` e expõe `PORT=8080`.
 
-Verifique:
+Build local da imagem:
 
-- backend Fastify rodando em `:5000`
-- frontend rodando em `:5173`
-- proxy configurado em `react-app/vite.config.js`
-- `SERVER_PORT`, `API_PORT` ou `PORT` corretos no ambiente do Vite
+```bash
+docker build -t cmmg-calendar .
+docker run -p 8080:8080 -e NODE_ENV=production cmmg-calendar
+```
 
-### Falha no TOTVS
+No DigitalOcean App Platform, `.do/app.yaml` aponta para `main`, usa o Dockerfile e habilita deploy automático por push.
 
-Verifique:
+## Qualidade e CI
 
-- credenciais válidas
-- cookie não expirado
-- disponibilidade do portal
-- variáveis `TOTVS_*` corretas no `.env`, se você sobrescreveu os defaults
+Antes de abrir PR:
 
-## Documentação relacionada
+```bash
+npm run check
+```
 
-- [README.md](README.md)
-- [docs/DOCUMENTATION_INDEX.md](docs/DOCUMENTATION_INDEX.md)
-- [docs/guides/INSTALLATION.md](docs/guides/INSTALLATION.md)
-- [docs/guides/WEB_INTERFACE.md](docs/guides/WEB_INTERFACE.md)
-- [docs/guides/API_REFERENCE.md](docs/guides/API_REFERENCE.md)
+O CI executa:
 
-## Créditos
+- backend: instalação, testes e build TypeScript;
+- frontend: instalação, lint, `tsc --noEmit` e build Vite;
+- CodeQL e workflows auxiliares de automação.
 
-Projeto desenvolvido e mantido por Bernardo Gomes.
+## Solução de Problemas
+
+Consulte [docs/guides/TROUBLESHOOTING.md](docs/guides/TROUBLESHOOTING.md) para erros de instalação, porta, proxy, upload, TOTVS, importação e build.
+
+## Mapa da Documentação
+
+- [README.md](README.md): visão geral e início rápido.
+- [docs/DOCUMENTATION_INDEX.md](docs/DOCUMENTATION_INDEX.md): navegação central.
+- [docs/guides/INSTALLATION.md](docs/guides/INSTALLATION.md): setup local.
+- [docs/guides/WEB_INTERFACE.md](docs/guides/WEB_INTERFACE.md): uso da interface.
+- [docs/guides/API_REFERENCE.md](docs/guides/API_REFERENCE.md): contratos HTTP.
+- [docs/guides/CLI.md](docs/guides/CLI.md): comandos locais.
+- [docs/guides/ARCHITECTURE.md](docs/guides/ARCHITECTURE.md): arquitetura técnica.
+- [docs/guides/GOOGLE_CALENDAR.md](docs/guides/GOOGLE_CALENDAR.md): importação no Google.
+- [docs/guides/THUNDERBIRD.md](docs/guides/THUNDERBIRD.md): importação por ICS.

--- a/README.md
+++ b/README.md
@@ -1,195 +1,186 @@
 # CMMG Calendar
 
-> Converta seu quadro de horários do Portal do Aluno CMMG em calendário digital — Google Calendar, Thunderbird, Outlook ou qualquer app iCalendar.
+> Transforme o quadro de horários do Portal do Aluno CMMG em arquivos prontos para Google Calendar, Thunderbird, Outlook, Apple Calendar e outros apps compatíveis com iCalendar.
 
-[![Deploy](https://img.shields.io/badge/deploy-DigitalOcean-0080ff?logo=digitalocean&logoColor=white)](https://calendar.scalpel.com.br)
-[![Live](https://img.shields.io/website?url=https%3A%2F%2Fcalendar.scalpel.com.br&label=status&up_message=online)](https://calendar.scalpel.com.br)
-[![Node](https://img.shields.io/badge/node-%5E20.19%20%7C%7C%20%3E%3D22.12-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
+[![Produção](https://img.shields.io/website?url=https%3A%2F%2Fcalendar.scalpel.com.br&label=calendar.scalpel.com.br)](https://calendar.scalpel.com.br)
+[![Node](https://img.shields.io/badge/node-%5E22.12%20%7C%7C%20%3E%3D24-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-**🌐 Acesse em produção: [calendar.scalpel.com.br](https://calendar.scalpel.com.br)**
+**Acesse em produção:** <https://calendar.scalpel.com.br>
 
----
+## Para Que Serve
 
-## O que faz
+O CMMG Calendar reduz o trabalho manual de cadastrar aulas uma por uma em um calendário. Ele lê os dados do `QuadroHorarioAluno` do TOTVS, valida a estrutura, calcula estatísticas do semestre e gera arquivos de calendário.
 
-O portal TOTVS exporta o horário acadêmico como `QuadroHorarioAluno.json`. Esta ferramenta lê esse arquivo — ou busca diretamente via login — e gera:
+Você pode usar de três formas:
 
-- **`GoogleAgenda.csv`** — importação direta no Google Calendar
-- **`Agenda.ics`** — compatível com Thunderbird, Outlook, Apple Calendar e qualquer cliente iCalendar
+| Fluxo | Quando usar | O que acontece |
+| --- | --- | --- |
+| Login TOTVS | Fluxo mais simples para estudantes | A API autentica no Portal do Aluno, consulta o horário e devolve a análise. A senha não é armazenada. |
+| Cookie TOTVS | Alternativa avançada quando o login automático falhar | Você cola um cookie de sessão ativo e a API consulta o horário. |
+| Upload JSON | Quando você já tem o arquivo local | Você envia `QuadroHorarioAluno.json` e a API apenas analisa o arquivo. |
 
-Além disso, exibe estatísticas do semestre: disciplinas, professores, salas, distribuição por dia e mês.
+Arquivos gerados:
 
----
+- `GoogleAgenda.csv`: importação pelo Google Calendar.
+- `ThunderbirdAgenda.ics`: formato universal para Thunderbird, Outlook, Apple Calendar e outros clientes.
 
-## Três formas de usar
+## Início Rápido
 
-### 1. Login automático _(recomendado)_
-Informe usuário e senha do Portal do Aluno. O servidor autentica no TOTVS, extrai o horário e retorna os dados — sem armazenar credenciais.
+Pré-requisitos:
 
-### 2. Cookie manual _(avançado)_
-Cole o header `Cookie` de uma sessão ativa (`ASP.NET_SessionId` + `.ASPXAUTH`). Útil quando o login automático não estiver disponível.
-
-### 3. Upload do arquivo
-Baixe o `QuadroHorarioAluno.json` manualmente pelo portal e faça upload. Sem necessidade de login.
-
----
-
-## Stack
-
-| Camada | Tecnologias |
-|--------|-------------|
-| Backend | Node.js · Fastify · TypeScript |
-| Frontend | React · Vite · TypeScript · CSS próprio |
-| Deploy | DigitalOcean App Platform · Docker multi-stage |
-| Testes | Node Test Runner nativo |
-
----
-
-## Desenvolvimento local
-
-### Pré-requisitos
-
-- Node.js `^20.19.0` ou `>=22.12.0`
-- npm 10+
-
-### Subir tudo de uma vez
+- Node.js `^22.12.0` ou `>=24.0.0`
+- npm `>=10`
+- Git
 
 ```bash
 git clone https://github.com/bernardopg/cmmg-calendar.git
 cd cmmg-calendar
-npm install   # instala root + react-app + server
-npm run dev   # backend (5000) + frontend Vite (5173) em paralelo
+npm install
+npm run dev
 ```
+
+Serviços em desenvolvimento:
 
 | Serviço | URL |
-|---------|-----|
-| Frontend (Vite dev server) | http://localhost:5173 |
-| API | http://localhost:5000/api/health |
+| --- | --- |
+| Frontend Vite | `http://localhost:5173` |
+| API Fastify | `http://localhost:5000/api/health` |
 
-O Vite faz proxy de `/api/*` para o Fastify local — sem CORS e sem alterar nada no código.
+O frontend usa chamadas relativas (`/api/...`) e o Vite encaminha essas chamadas para o backend local.
 
-### Processos separados
+## Comandos Principais
+
+| Comando | Descrição |
+| --- | --- |
+| `npm run dev` | Sobe backend e frontend em watch mode. |
+| `npm run dev:server` | Sobe apenas o Fastify em `:5000`. |
+| `npm run dev:client` | Sobe apenas o Vite em `:5173`. |
+| `npm run lint` | Executa lint do frontend. |
+| `npm run test` | Executa testes do backend. |
+| `npm run build` | Compila frontend e backend. |
+| `npm run check` | Executa lint, testes e build. |
+| `npm start` | Inicia o backend compilado, servindo também o build do frontend. |
+
+Utilitários CLI:
 
 ```bash
-npm run dev:server   # apenas o Fastify (watch mode)
-npm run dev:client   # apenas o Vite
+npm run schedule:analyze -- --input data/QuadroHorarioAluno.json
+npm run schedule:export -- --input data/QuadroHorarioAluno.json
+npm run totvs:fetch -- --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...'
 ```
 
-### Variáveis de ambiente
+## Stack Atual
 
-Crie `.env` na raiz (opcional — os valores abaixo já são o padrão):
+| Camada | Tecnologias |
+| --- | --- |
+| Frontend | React 19, Vite 8, TypeScript 6, CSS próprio |
+| Backend | Node.js, Fastify 5, TypeScript 6, Zod, Undici |
+| Testes | Node Test Runner nativo |
+| Produção | Docker multi-stage em Node 24, DigitalOcean App Platform |
+| CI | GitHub Actions com Node 24, lint, typecheck, build, testes e CodeQL |
+
+## Arquitetura em Uma Página
+
+```text
+cmmg-calendar/
+├── react-app/                 # SPA React/Vite
+│   └── src/
+│       ├── pages/             # rotas /, /gerador, /guia, /faq, /sobre
+│       ├── hooks/             # estado de API, upload, tema e análise
+│       ├── components/        # UI, layout, resultados, gráficos
+│       └── utils/             # exportação CSV/ICS e utilitários
+├── server/                    # API Fastify + CLIs Node
+│   └── src/
+│       ├── routes/            # /api/health, /api/analyze, /api/extract-analyze, /api/totvs-login
+│       ├── services/          # análise, TOTVS, parsing e exportação
+│       └── cli/               # comandos locais
+├── docs/                      # documentação técnica e guias de uso
+├── Dockerfile                 # imagem de produção
+└── .do/app.yaml               # deploy no DigitalOcean App Platform
+```
+
+Em produção, o backend serve a API em `/api/*` e também os arquivos estáticos gerados em `react-app/dist`.
+
+## API Resumida
+
+Base local: `http://localhost:5000/api`
+
+| Método | Endpoint | Uso |
+| --- | --- | --- |
+| `GET` | `/api/health` | Verifica disponibilidade da API. |
+| `POST` | `/api/analyze` | Analisa um `.json` enviado por `multipart/form-data`. |
+| `POST` | `/api/extract-analyze` | Consulta TOTVS usando cookie de sessão. |
+| `POST` | `/api/totvs-login` | Autentica no TOTVS com usuário/senha e busca o horário. |
+
+Exemplo:
+
+```bash
+curl -X POST \
+  -F "file=@data/QuadroHorarioAluno.json" \
+  http://localhost:5000/api/analyze
+```
+
+Veja contratos completos em [docs/guides/API_REFERENCE.md](docs/guides/API_REFERENCE.md).
+
+## Configuração
+
+A aplicação funciona com valores padrão para o portal CMMG. Sobrescreva apenas se necessário.
 
 ```env
 PORT=5000
 HOST=0.0.0.0
 MAX_FILE_SIZE_MB=10
 TOTVS_TIMEOUT_MS=30000
+TOTVS_BASE_URL=https://fundacaoeducacional132827.rm.cloudtotvs.com.br
 TOTVS_DEFAULT_ALIAS=CorporeRM
+CORS_ORIGINS=https://calendar.scalpel.com.br
 ```
 
-As URLs do TOTVS (`TOTVS_QUADRO_URL`, `TOTVS_LOGIN_URL`, etc.) têm valores padrão apontando para o portal da CMMG. Só precise sobrescrever se sua instituição usar uma URL diferente.
-
----
-
-## CLI
-
-Para uso fora da interface web:
-
-```bash
-# Exportar CSV e ICS a partir de um arquivo local
-npm run schedule:export -- --input data/QuadroHorarioAluno.json
-
-# Apenas analisar (sem exportar)
-npm run schedule:analyze -- --input data/QuadroHorarioAluno.json
-
-# Buscar via cookie de sessão
-npm run totvs:fetch -- --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...'
-```
-
-Saída gerada em `output/`.
-
----
-
-## API
-
-```
-GET  /api/health           → status do servidor
-POST /api/analyze          → analisa JSON enviado por upload (multipart)
-POST /api/extract-analyze  → extrai e analisa via cookie TOTVS
-POST /api/totvs-login      → autentica e extrai via usuário/senha
-```
-
-Exemplo rápido:
-
-```bash
-curl -X POST \
-  -F "file=@QuadroHorarioAluno.json" \
-  https://calendar.scalpel.com.br/api/analyze
-```
-
----
-
-## Estrutura do projeto
-
-```
-cmmg-calendar/
-├── server/          # Fastify + TypeScript (backend)
-│   └── src/
-│       ├── routes/  # endpoints da API
-│       └── services/# lógica TOTVS e análise
-├── react-app/       # React + Vite (frontend)
-│   └── src/
-│       ├── pages/
-│       └── components/
-├── Dockerfile       # build multi-stage para produção
-├── .do/app.yaml     # spec do DigitalOcean App Platform
-└── docs/            # guias detalhados
-```
-
----
-
-## Deploy
-
-O projeto usa um **Dockerfile multi-stage** para produção:
-
-1. **Stage build** — instala todas as dependências e compila React + TypeScript
-2. **Stage runner** — copia apenas os artefatos compilados e as dependências de produção
-
-```bash
-# Build local da imagem
-docker build -t cmmg-calendar .
-docker run -p 8080:8080 -e NODE_ENV=production cmmg-calendar
-docker run -p 8080:8080 -e NODE_ENV=production -e PORT=8080 cmmg-calendar
-```
-
-No DigitalOcean App Platform, o deploy é automático a cada push para `main`.
-
----
+Também existem variáveis específicas para endpoints TOTVS, descritas no [guia de instalação](docs/guides/INSTALLATION.md).
 
 ## Documentação
 
-- [Documentação completa](DOCUMENTACAO.md)
-- [Instalação detalhada](docs/guides/INSTALLATION.md)
-- [Interface web](docs/guides/WEB_INTERFACE.md)
-- [Referência da API](docs/guides/API_REFERENCE.md)
-- [Google Calendar](docs/guides/GOOGLE_CALENDAR.md)
-- [Thunderbird / iCalendar](docs/guides/THUNDERBIRD.md)
+Comece pelo caminho abaixo:
 
----
+1. [Manual completo](DOCUMENTACAO.md)
+2. [Índice da documentação](docs/DOCUMENTATION_INDEX.md)
+3. [Instalação e ambiente](docs/guides/INSTALLATION.md)
+4. [Interface web](docs/guides/WEB_INTERFACE.md)
+5. [Referência da API](docs/guides/API_REFERENCE.md)
+6. [CLI](docs/guides/CLI.md)
+7. [Arquitetura](docs/guides/ARCHITECTURE.md)
+8. [Solução de problemas](docs/guides/TROUBLESHOOTING.md)
+
+Guias de importação:
+
+- [Google Calendar](docs/guides/GOOGLE_CALENDAR.md)
+- [Thunderbird e iCalendar](docs/guides/THUNDERBIRD.md)
+
+## Segurança e Privacidade
+
+- Credenciais TOTVS são usadas apenas para a requisição de login e não são persistidas pela aplicação.
+- Cookies e senhas são mascarados nos logs do backend.
+- Uploads têm limite configurável por `MAX_FILE_SIZE_MB`.
+- Endpoints sensíveis têm rate limit.
+- Em produção, CORS só é liberado para origens explicitamente configuradas em `CORS_ORIGINS`.
+
+Para reportar vulnerabilidades, consulte [SECURITY.md](SECURITY.md).
 
 ## Contribuição
 
-Consulte [CONTRIBUTING.md](CONTRIBUTING.md).
+Antes de abrir PR:
 
-## Segurança
+```bash
+npm run check
+```
 
-Consulte [SECURITY.md](SECURITY.md).
+Leia [CONTRIBUTING.md](CONTRIBUTING.md) para o fluxo recomendado.
 
 ## Licença
 
-MIT — consulte [LICENSE](LICENSE).
+MIT. Consulte [LICENSE](LICENSE).
 
----
+## Créditos
 
-**Autor:** Bernardo Gomes · [bebitterbebetter.com.br](https://bebitterbebetter.com.br) · [@be.pgomes](https://instagram.com/be.pgomes) · [github.com/bernardopg](https://github.com/bernardopg)
+Projeto desenvolvido e mantido por Bernardo Gomes. Veja [CREDITS.md](CREDITS.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,33 +1,53 @@
 # Política de Segurança
 
-## Versões suportadas
+## Versões Suportadas
 
-O projeto atualmente mantém correções de segurança na branch principal (`main`).
+Correções de segurança são mantidas na branch `main`.
 
-## Como reportar vulnerabilidades
+## Como Reportar Vulnerabilidades
 
-Se você identificar uma vulnerabilidade, evite abrir issue pública inicialmente.
+Não abra issue pública com detalhes exploráveis.
 
-Envie um relato com:
+Envie um relato responsável com:
 
 - descrição do problema;
 - impacto potencial;
 - passos de reprodução;
-- sugestão de mitigação (se houver).
+- ambiente afetado;
+- sugestão de mitigação, se houver.
 
-Contato para reporte responsável:
+Contato:
 
-- E-mail: <bernardo.gomes@bebitterbebetter.com.br>
+- <bernardo.gomes@bebitterbebetter.com.br>
 
-## Processo de resposta
+## Processo de Resposta
 
-1. Confirmação de recebimento do reporte.
-2. Triagem técnica.
-3. Correção e validação.
-4. Publicação da correção.
+1. Recebimento e triagem.
+2. Reprodução técnica.
+3. Correção ou mitigação.
+4. Validação local e em CI.
+5. Publicação da correção.
 
-## Boas práticas para usuários
+## Controles Atuais
 
-- mantenha dependências atualizadas;
-- não exponha a API em produção sem controles adicionais;
-- valide entradas e limites de upload.
+- Senhas e cookies TOTVS não são persistidos pela aplicação.
+- Campos sensíveis são redigidos nos logs do backend.
+- Uploads são limitados por `MAX_FILE_SIZE_MB`.
+- Rotas sensíveis têm rate limit.
+- CORS em produção é fechado por padrão e liberado apenas via `CORS_ORIGINS`.
+- CLIs rejeitam caminhos fora da raiz do projeto.
+- Headers básicos de segurança são aplicados em todas as respostas.
+
+## Boas Práticas Para Usuários
+
+- Não compartilhe cookie TOTVS em issues, chats públicos ou prints.
+- Use o site oficial em produção: <https://calendar.scalpel.com.br>.
+- Revogue ou renove sessões se suspeitar exposição de cookie.
+- Importe arquivos de calendário em um calendário dedicado para evitar misturar dados pessoais.
+
+## Boas Práticas Para Mantenedores
+
+- Rode `npm run check` antes de mergear mudanças relevantes.
+- Não registre `password`, `totvs_cookie`, `authorization` ou `cookie` em logs.
+- Não adicione exemplos com credenciais reais.
+- Revise mudanças em dependências com atenção a breaking changes e advisorys.

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,41 +1,57 @@
-# Índice de Documentação
+# Índice da Documentação
 
-Navegação centralizada da documentação do projeto.
+Use este arquivo como mapa de navegação. A documentação está organizada por objetivo: começar rápido, operar localmente, integrar com a API, entender a arquitetura ou resolver problemas.
 
-## Guias principais
+## Leitura Recomendada
 
-- [README](../README.md) — visão geral e início rápido
-- [DOCUMENTACAO](../DOCUMENTACAO.md) — guia completo de uso, execução e solução de problemas
-- [Instalação](guides/INSTALLATION.md) — setup local e variáveis de ambiente
-- [Interface Web](guides/WEB_INTERFACE.md) — fluxos de uso da UI
-- [Referência da API](guides/API_REFERENCE.md) — contratos dos endpoints
-- [Status da Migração](guides/MIGRATION_STATUS.md)
+| Se você quer... | Leia |
+| --- | --- |
+| Entender o projeto em poucos minutos | [README](../README.md) |
+| Ter a visão completa do produto e da manutenção | [Manual do Projeto](../DOCUMENTACAO.md) |
+| Rodar o projeto localmente | [Instalação](guides/INSTALLATION.md) |
+| Usar a aplicação web | [Interface Web](guides/WEB_INTERFACE.md) |
+| Integrar com endpoints HTTP | [Referência da API](guides/API_REFERENCE.md) |
+| Usar comandos no terminal | [CLI](guides/CLI.md) |
+| Entender módulos, fluxos e deploy | [Arquitetura](guides/ARCHITECTURE.md) |
+| Corrigir erros comuns | [Solução de Problemas](guides/TROUBLESHOOTING.md) |
 
-## Guias de importação
+## Guias de Uso Final
 
+- [Interface Web](guides/WEB_INTERFACE.md)
 - [Google Calendar](guides/GOOGLE_CALENDAR.md)
-- [Thunderbird](guides/THUNDERBIRD.md)
+- [Thunderbird e iCalendar](guides/THUNDERBIRD.md)
 
-## Material de apoio
+## Guias Técnicos
 
-- [README_VISUAL](README_VISUAL.md) — organização de capturas e material visual
+- [Instalação](guides/INSTALLATION.md)
+- [Referência da API](guides/API_REFERENCE.md)
+- [CLI](guides/CLI.md)
+- [Arquitetura](guides/ARCHITECTURE.md)
+- [Status da Migração](guides/MIGRATION_STATUS.md)
+- [Solução de Problemas](guides/TROUBLESHOOTING.md)
 
 ## Governança
 
 - [Contribuição](../CONTRIBUTING.md)
-- [Código de Conduta](../CODE_OF_CONDUCT.md)
 - [Segurança](../SECURITY.md)
-- [Licença](../LICENSE)
+- [Código de Conduta](../CODE_OF_CONDUCT.md)
 - [Créditos](../CREDITS.md)
+- [Licença](../LICENSE)
 
-## Contexto para agentes
+## Materiais Visuais
 
-- [CLAUDE](../CLAUDE.md) — contexto operacional para assistentes/agentes; não substitui a documentação principal para humanos
+- [Padrão de imagens da documentação](README_VISUAL.md)
 
-## Fluxo recomendado
+## Contexto Para Agentes
 
-1. Leia o [README](../README.md)
-2. Siga o [Guia de Instalação](guides/INSTALLATION.md)
-3. Em desenvolvimento local, suba `npm run dev`
-4. Use o [Guia da Interface Web](guides/WEB_INTERFACE.md) ou a [Referência da API](guides/API_REFERENCE.md)
-5. Consulte o guia de importação apropriado
+- [CLAUDE.md](../CLAUDE.md) contém contexto operacional para assistentes. Ele não substitui a documentação para humanos.
+
+## Checklist Para Atualizar Documentação
+
+Antes de fechar uma mudança que afeta comportamento, confira:
+
+- `README.md` continua correto para novos usuários.
+- `DOCUMENTACAO.md` reflete arquitetura, comandos e variáveis atuais.
+- Guias em `docs/guides/` não citam rotas, comandos ou versões antigas.
+- Exemplos de `curl` ainda batem com a API real.
+- Links relativos funcionam a partir do arquivo onde aparecem.

--- a/docs/README_VISUAL.md
+++ b/docs/README_VISUAL.md
@@ -1,54 +1,56 @@
-# Guia Visual da Documentação
+# Padrão Visual da Documentação
 
-Este arquivo define padrão para capturas de tela e materiais visuais usados na documentação.
+Este arquivo define como capturas de tela e imagens devem ser organizadas quando forem adicionadas à documentação.
 
 ## Objetivo
 
-Manter consistência visual e qualidade nas imagens de guias e README.
+Manter imagens úteis, consistentes e seguras. Uma boa imagem deve explicar uma etapa do fluxo sem expor dados pessoais.
 
-## Estrutura sugerida
+## Estrutura Recomendada
 
 ```text
 docs/images/
 ├── web/
 ├── google-calendar/
 ├── thunderbird/
-└── branding/
+└── architecture/
 ```
 
-## Imagens prioritárias
+## Imagens Prioritárias
 
-1. Tela inicial da aplicação web
-2. Resultado da análise
-3. Exportação CSV e ICS
-4. Passos de importação no Google Calendar
-5. Passos de importação no Thunderbird
+| Caminho sugerido | Conteúdo |
+| --- | --- |
+| `docs/images/web/landing.png` | Página inicial em desktop. |
+| `docs/images/web/generator-login.png` | Fluxo de login TOTVS, sem credenciais reais. |
+| `docs/images/web/analysis-results.png` | Resultado da análise com dados fictícios. |
+| `docs/images/web/export-buttons.png` | Botões de exportação CSV/ICS. |
+| `docs/images/google-calendar/import.png` | Tela de importação do Google Calendar. |
+| `docs/images/thunderbird/import.png` | Tela de importação do Thunderbird. |
 
-## Padrão de captura
+## Regras de Segurança
 
-- resolução mínima: 1280x720;
-- formato: PNG;
-- sem dados pessoais ou sensíveis;
-- idioma da interface consistente por guia;
-- foco no fluxo da tarefa (evitar elementos irrelevantes).
+- Não incluir nome real, RA, senha, cookie, e-mail pessoal ou token.
+- Não mostrar dados reais de turma se houver risco de exposição.
+- Preferir dados fictícios ou borrados.
+- Conferir screenshots antes de commit.
 
-## Convenção de nomes
+## Padrão de Captura
 
-- `web-home.png`
-- `web-analysis-result.png`
-- `google-import-step-1.png`
-- `thunderbird-import-step-1.png`
+- Formato: PNG.
+- Largura recomendada: 1280px ou maior.
+- Tema consistente por guia.
+- Zoom em 100%.
+- Sem blur excessivo.
+- Recorte limpo e foco na ação descrita.
 
-## Checklist de qualidade
+## Texto Alternativo
 
-- texto legível em 100% de zoom;
-- sem blur ou compressão agressiva;
-- recorte limpo;
-- passo retratado confere com o texto do guia;
-- arquivo otimizado para web.
+Toda imagem adicionada em Markdown deve ter texto alternativo útil, descrevendo a tela e a ação retratada. Evite alt text genérico como `imagem`, `screenshot` ou `print`.
 
-## Próximos passos
+## Checklist Para PRs Com Imagens
 
-- adicionar as imagens em `docs/images/`;
-- referenciar as imagens nos guias correspondentes;
-- manter este padrão em novos PRs de documentação.
+- [ ] Imagem não contém dados sensíveis.
+- [ ] Nome do arquivo é descritivo.
+- [ ] Markdown usa texto alternativo claro.
+- [ ] A imagem corresponde ao texto do guia.
+- [ ] O arquivo foi otimizado para web.

--- a/docs/guides/API_REFERENCE.md
+++ b/docs/guides/API_REFERENCE.md
@@ -1,18 +1,50 @@
 # Referência da API
 
-Base URL local do backend: `http://localhost:5000/api`
+Base local: `http://localhost:5000/api`
 
-Em produção, a expectativa é servir a API no mesmo domínio da SPA, por exemplo `https://scalpel.com.br/api`.
+Base em produção: `https://calendar.scalpel.com.br/api`
 
-## Autenticação
+## Convenções
 
-Os endpoints locais não exigem autenticação própria da aplicação. Os fluxos TOTVS dependem de credenciais do portal ou de um cookie de sessão válido.
+Respostas de sucesso:
 
-## Endpoints
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
 
-### `GET /api/health`
+Respostas de erro:
 
-Verifica disponibilidade da API.
+```json
+{
+  "success": false,
+  "error": "Mensagem legível para o usuário"
+}
+```
+
+Os endpoints da aplicação não exigem autenticação própria. Os fluxos TOTVS dependem de credenciais do Portal do Aluno ou de um cookie de sessão válido.
+
+## Segurança Aplicada pela API
+
+- Rate limit por rota.
+- Limite de upload configurável por `MAX_FILE_SIZE_MB`.
+- Redação de `cookie`, `authorization`, `password` e `totvs_cookie` nos logs.
+- Headers básicos: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` e `X-DNS-Prefetch-Control`.
+- CORS liberado em produção apenas via `CORS_ORIGINS`.
+
+## `GET /api/health`
+
+Verifica se a API está disponível.
+
+Rate limit: `60` requisições por minuto.
+
+Exemplo:
+
+```bash
+curl http://localhost:5000/api/health
+```
 
 Resposta `200`:
 
@@ -21,18 +53,23 @@ Resposta `200`:
   "status": "up",
   "message": "API funcionando",
   "port": 5000,
-  "timestamp": "2026-03-17T14:32:28.691Z"
+  "timestamp": "2026-06-16T14:32:28.691Z"
 }
 ```
 
----
+## `POST /api/analyze`
 
-### `POST /api/analyze`
+Analisa um arquivo `QuadroHorarioAluno.json` enviado por upload.
 
-Analisa um arquivo de horário acadêmico enviado em `multipart/form-data`.
+Content type: `multipart/form-data`
 
-- Campo obrigatório: `file` (`.json`)
-- Limite de taxa: `10 por minuto`
+Campo obrigatório:
+
+| Campo | Tipo | Descrição |
+| --- | --- | --- |
+| `file` | arquivo `.json` | Payload do TOTVS com `data.SHorarioAluno`. |
+
+Rate limit: `10` requisições por minuto.
 
 Exemplo:
 
@@ -49,35 +86,57 @@ Resposta `200`:
   "success": true,
   "data": {
     "statistics": {
-      "total_entries": 677,
-      "valid_entries": 670,
-      "invalid_entries": 7
+      "total_entries": 120,
+      "valid_entries": 118,
+      "invalid_entries": 2
     },
-    "subjects": {},
-    "time_slots": {},
-    "locations": {},
-    "days_of_week": {},
-    "monthly_distribution": {}
+    "subjects": {
+      "Anatomia": 18
+    },
+    "time_slots": {
+      "08:00:00 - 10:00:00": 12
+    },
+    "locations": {
+      "Campus": 42
+    },
+    "days_of_week": {
+      "Segunda": 20,
+      "Terça": 20
+    },
+    "monthly_distribution": {
+      "2026-03": 30
+    }
   }
 }
 ```
 
 Erros comuns:
 
-- `400`: arquivo ausente, extensão inválida ou JSON inválido
-- `413`: arquivo acima do tamanho máximo
-- `429`: limite de taxa excedido
-- `500`: erro interno
+| Status | Quando ocorre |
+| --- | --- |
+| `400` | arquivo ausente, sem nome, extensão diferente de `.json` ou JSON inválido |
+| `413` | arquivo maior que `MAX_FILE_SIZE_MB` |
+| `422` | estrutura do JSON não contém dados processáveis |
+| `429` | limite de taxa excedido |
+| `500` | erro inesperado |
 
----
+## `POST /api/extract-analyze`
 
-### `POST /api/extract-analyze`
+Consulta o `QuadroHorarioAluno` no TOTVS usando cookie de sessão e devolve análise mais dados brutos.
 
-Busca o `QuadroHorarioAluno` no TOTVS usando um cookie de sessão já autenticado e devolve os dados brutos mais a análise consolidada.
+Content type: `application/json`
 
-- Body JSON opcional: `{"totvs_cookie":"ASP.NET_SessionId=...; .ASPXAUTH=..."}`
-- Se `totvs_cookie` não for enviado, a API tenta `TOTVS_COOKIE` no ambiente
-- Limite de taxa: `5 por minuto`
+Body:
+
+```json
+{
+  "totvs_cookie": "ASP.NET_SessionId=...; .ASPXAUTH=..."
+}
+```
+
+`totvs_cookie` é opcional no body se `TOTVS_COOKIE` estiver configurado no backend.
+
+Rate limit: `5` requisições por minuto.
 
 Exemplo:
 
@@ -96,10 +155,15 @@ Resposta `200`:
   "data": {
     "analysis": {
       "statistics": {
-        "total_entries": 677,
-        "valid_entries": 670,
-        "invalid_entries": 7
-      }
+        "total_entries": 120,
+        "valid_entries": 118,
+        "invalid_entries": 2
+      },
+      "subjects": {},
+      "time_slots": {},
+      "locations": {},
+      "days_of_week": {},
+      "monthly_distribution": {}
     },
     "schedule_data": {
       "data": {
@@ -112,18 +176,40 @@ Resposta `200`:
 
 Erros comuns:
 
-- `400`: cookie ausente
-- `401`: sessão TOTVS inválida ou expirada
-- `502`: falha de conexão ou resposta inválida do TOTVS
+| Status | Quando ocorre |
+| --- | --- |
+| `400` | body inválido ou cookie ausente |
+| `401` | cookie expirado ou não autorizado no TOTVS |
+| `422` | TOTVS respondeu payload sem estrutura esperada |
+| `429` | limite de taxa excedido |
+| `502` | falha de conexão, HTTP inesperado ou JSON inválido do TOTVS |
+| `500` | erro inesperado |
 
----
+## `POST /api/totvs-login`
 
-### `POST /api/totvs-login`
+Recebe credenciais do Portal do Aluno, autentica no TOTVS, seleciona contexto acadêmico, consulta o horário e devolve análise mais dados brutos.
 
-Recebe credenciais do Portal do Aluno, faz login no TOTVS, busca o horário e devolve análise mais dados brutos.
+Content type: `application/json`
 
-- Body JSON obrigatório: `{"user":"...","password":"..."}`
-- Limite de taxa: `5 por minuto`
+Body:
+
+```json
+{
+  "user": "seu-usuario",
+  "password": "sua-senha",
+  "alias": "CorporeRM"
+}
+```
+
+Campos:
+
+| Campo | Obrigatório | Descrição |
+| --- | --- | --- |
+| `user` | sim | Usuário, RA ou login do Portal do Aluno. |
+| `password` | sim | Senha do Portal do Aluno. |
+| `alias` | não | Alias TOTVS desejado; se ausente, usa `TOTVS_DEFAULT_ALIAS`. |
+
+Rate limit: `5` requisições por minuto.
 
 Exemplo:
 
@@ -134,54 +220,53 @@ curl -X POST \
   http://localhost:5000/api/totvs-login
 ```
 
+Resposta `200`: mesmo formato de `/api/extract-analyze`.
+
 Erros comuns:
 
-- `400`: usuário ou senha ausentes
-- `401`: credenciais inválidas
-- `502`: falha ao consultar TOTVS
+| Status | Quando ocorre |
+| --- | --- |
+| `400` | usuário ou senha ausentes, body inválido ou contexto inválido |
+| `401` | credenciais inválidas ou não autorizadas |
+| `422` | payload TOTVS sem estrutura esperada |
+| `429` | limite de taxa excedido |
+| `502` | falha de conexão, HTTP inesperado ou JSON inválido do TOTVS |
+| `500` | erro inesperado |
 
----
-
-## Exportação
-
-Na arquitetura Node atual, a exportação CSV e ICS da interface é client-side e não passa pela API.
-
-Arquivos relevantes:
-
-- `react-app/src/utils/exportUtils.ts`
-- `react-app/src/components/results/ExportButtons.tsx`
-
-Observação:
-
-- o backend também oferece CLI para exportação via `npm run schedule:export -- --input ...`
-
-## Formato esperado do JSON
+## Formato de Entrada Esperado
 
 ```json
 {
   "data": {
     "SHorarioAluno": [
       {
-        "NOME": "Matemática",
-        "DATAINICIAL": "2025-03-10T00:00:00",
-        "DATAFINAL": "2025-03-10T00:00:00",
+        "NOME": "Anatomia",
+        "DATAINICIAL": "2026-03-10T00:00:00",
+        "DATAFINAL": "2026-03-10T00:00:00",
         "HORAINICIAL": "08:00:00",
         "HORAFINAL": "10:00:00",
+        "DIASEMANA": "2",
         "PREDIO": "Campus",
         "BLOCO": "A",
         "SALA": "101",
-        "CODTURMA": "MAT01",
-        "DIASEMANA": "1"
+        "CODTURMA": "MED01",
+        "CODSUBTURMA": "A",
+        "NOMEREDUZIDO": "ANA",
+        "URLAULAONLINE": "https://exemplo.invalid/aula"
       }
     ]
   }
 }
 ```
 
-## Boas práticas de integração
+## Integração Recomendada
 
-- valide o JSON antes do envio
-- trate `400`, `401`, `413`, `429`, `500` e `502`
-- use timeout de rede no cliente
-- não persista credenciais TOTVS desnecessariamente
-- no frontend web, prefira sempre chamadas relativas como `fetch('/api/...')`
+- Use chamadas relativas (`/api/...`) quando o frontend estiver no mesmo domínio da API.
+- Trate explicitamente `400`, `401`, `413`, `422`, `429`, `500` e `502`.
+- Não persista senha ou cookie TOTVS no cliente.
+- Use `AbortController` ou timeout no cliente para evitar requisições penduradas.
+- Mostre as mensagens de `error` retornadas pela API; elas já são pensadas para usuário final.
+
+## Exportação
+
+A API HTTP não possui endpoint de exportação. Na interface web, CSV e ICS são gerados no navegador por `react-app/src/utils/exportUtils.ts`. Para exportação no terminal, use a CLI documentada em [CLI.md](CLI.md).

--- a/docs/guides/ARCHITECTURE.md
+++ b/docs/guides/ARCHITECTURE.md
@@ -1,0 +1,160 @@
+# Arquitetura
+
+Este guia descreve a arquitetura atual do CMMG Calendar para manutenção técnica.
+
+## Visão Geral
+
+```text
+Usuário
+  |
+  v
+React SPA (react-app)
+  |
+  | /api/analyze
+  | /api/extract-analyze
+  | /api/totvs-login
+  v
+Fastify API (server)
+  |
+  | quando necessário
+  v
+Portal TOTVS Educacional
+```
+
+Em desenvolvimento, o Vite serve a SPA e faz proxy de `/api` para o Fastify. Em produção, o Fastify serve a API e os arquivos de `react-app/dist` no mesmo processo.
+
+## Diretórios
+
+```text
+react-app/
+  src/
+    components/      # layout, UI, gráficos, resultados e upload
+    hooks/           # estado da API, tema, upload e análise
+    pages/           # rotas da SPA
+    types/           # tipos usados no frontend
+    utils/           # exportação e utilitários
+
+server/
+  src/
+    cli/             # comandos locais
+    routes/          # plugins Fastify por endpoint
+    services/        # regras de negócio e integração TOTVS
+    config.ts        # ambiente e paths
+    index.ts         # composição e bootstrap do servidor
+    types.ts         # contratos internos
+```
+
+## Frontend
+
+Rotas principais:
+
+| Rota | Componente | Descrição |
+| --- | --- | --- |
+| `/` | `LandingPage` | Página inicial. |
+| `/gerador` | `HomePage` | Fluxos de login, cookie, upload, análise e exportação. |
+| `/guia` | `GuidePage` | Ajuda dentro da aplicação. |
+| `/faq` | `FaqPage` | Perguntas frequentes. |
+| `/sobre` | `AboutPage` | Contexto do projeto. |
+
+Hooks importantes:
+
+- `useApiHealth`: monitora `/api/health`.
+- `useFileUpload`: valida arquivo `.json` e formato mínimo `data.SHorarioAluno`.
+- `useScheduleAnalysis`: gerencia chamadas da API e cancela requisições antigas com `AbortController`.
+- `useToast`: feedback visual e limpeza de timers.
+
+Exportação web:
+
+- `exportToCSV`: gera `GoogleAgenda.csv`.
+- `exportToICS`: gera `ThunderbirdAgenda.ics`.
+- IDs são gerados com utilitário seguro, evitando fallback com `Math.random`.
+
+## Backend
+
+`server/src/index.ts` monta o Fastify com:
+
+- logger com campos sensíveis redigidos;
+- headers básicos de segurança;
+- CORS seguro por padrão;
+- rate limit por rota;
+- upload multipart com limite de tamanho;
+- arquivos estáticos do frontend quando `react-app/dist` existe;
+- handlers padronizados de erro e not found.
+
+Rotas:
+
+| Rota | Arquivo | Responsabilidade |
+| --- | --- | --- |
+| `GET /api/health` | `routes/health.ts` | Status da API. |
+| `POST /api/analyze` | `routes/analyze.ts` | Analisa upload JSON. |
+| `POST /api/extract-analyze` | `routes/extractAnalyze.ts` | Busca no TOTVS por cookie. |
+| `POST /api/totvs-login` | `routes/totvsLogin.ts` | Login TOTVS e extração. |
+
+Serviços:
+
+- `analyzeSchedule.ts`: transforma entries em estatísticas.
+- `scheduleEntries.ts`: extrai e valida `data.SHorarioAluno`.
+- `totvsClient.ts`: login, contexto, cookie jar e fetch do TOTVS.
+- `totvsParsers.ts`: parsing de erros, formulários e contexto TOTVS.
+- `exportSchedule.ts`: CSV/ICS para CLI.
+
+## TOTVS
+
+O backend usa `TOTVS_BASE_URL` e monta endpoints padrão para CMMG. Quando necessário, cada endpoint pode ser sobrescrito por variável específica.
+
+Fluxo de login:
+
+1. Buscar formulário de login.
+2. Enviar credenciais.
+3. Executar auto-login.
+4. Buscar contextos acadêmicos.
+5. Selecionar contexto por alias ou default.
+6. Consultar `QuadroHorarioAluno`.
+7. Validar payload e analisar.
+
+## Build e Produção
+
+`npm run build` gera:
+
+- `react-app/dist`
+- `server/dist`
+
+O Dockerfile tem dois estágios:
+
+| Estágio | Função |
+| --- | --- |
+| `builder` | instala dependências completas e compila frontend/backend |
+| `runner` | instala dependências de produção do servidor e roda `node server/dist/index.js` |
+
+O contêiner roda como usuário `node`, expõe `8080` e usa `HOST=0.0.0.0`.
+
+## CI
+
+O workflow principal usa Node 24.
+
+Job `backend`:
+
+- instala dependências da raiz e do servidor;
+- executa testes;
+- compila TypeScript.
+
+Job `frontend`:
+
+- instala dependências do frontend;
+- executa lint;
+- executa `tsc --noEmit`;
+- executa build Vite.
+
+## Decisões Relevantes
+
+- Backend canônico é Node/Fastify; não há backend Python ativo.
+- Exportação da interface é client-side para evitar endpoints extras e manter download imediato.
+- CLI mantém exportação server-side para automação local.
+- CORS em produção é fechado por padrão.
+- Caminhos das CLIs são restritos à raiz do projeto para evitar path traversal.
+
+## Relacionados
+
+- [Manual do Projeto](../../DOCUMENTACAO.md)
+- [Referência da API](API_REFERENCE.md)
+- [CLI](CLI.md)

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -1,0 +1,116 @@
+# CLI
+
+O projeto inclui utilitários de terminal no backend Node. Eles são úteis para automação, depuração e uso sem interface web.
+
+Todos os comandos devem ser executados na raiz do repositório.
+
+## Pré-requisitos
+
+```bash
+npm install
+```
+
+Opcionalmente, crie `.env` na raiz ou `server/.env` para variáveis TOTVS.
+
+## Analisar JSON
+
+Comando:
+
+```bash
+npm run schedule:analyze -- --input data/QuadroHorarioAluno.json
+```
+
+Se `--input` não for informado, o padrão é:
+
+```text
+data/QuadroHorarioAluno.json
+```
+
+Saída: JSON da análise impresso no terminal.
+
+Exemplo de saída:
+
+```json
+{
+  "statistics": {
+    "total_entries": 120,
+    "valid_entries": 118,
+    "invalid_entries": 2
+  },
+  "subjects": {},
+  "time_slots": {},
+  "locations": {},
+  "days_of_week": {},
+  "monthly_distribution": {}
+}
+```
+
+## Exportar CSV e ICS
+
+Comando:
+
+```bash
+npm run schedule:export -- --input data/QuadroHorarioAluno.json
+```
+
+Saída padrão:
+
+```text
+output/GoogleAgenda.csv
+output/ThunderbirdAgenda.ics
+```
+
+Para escolher outro diretório:
+
+```bash
+npm run schedule:export -- \
+  --input data/QuadroHorarioAluno.json \
+  --output-dir output/semestre-2026-1
+```
+
+## Buscar Horário no TOTVS por Cookie
+
+Comando com cookie explícito:
+
+```bash
+npm run totvs:fetch -- --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...'
+```
+
+Comando usando `TOTVS_COOKIE` do ambiente:
+
+```bash
+TOTVS_COOKIE='ASP.NET_SessionId=...; .ASPXAUTH=...' npm run totvs:fetch
+```
+
+Saída padrão:
+
+```text
+data/QuadroHorarioAluno.json
+```
+
+Para escolher outro arquivo:
+
+```bash
+npm run totvs:fetch -- \
+  --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...' \
+  --output data/meu-horario.json
+```
+
+## Segurança dos Caminhos
+
+As CLIs validam os caminhos de entrada e saída para que permaneçam dentro da raiz do projeto. Caminhos absolutos fora do repositório e path traversal com `../` são rejeitados.
+
+## Erros Comuns
+
+| Erro | Causa provável | Correção |
+| --- | --- | --- |
+| `Arquivo não encontrado` | `--input` aponta para arquivo inexistente | confira o caminho dentro do projeto |
+| `JSON inválido` | arquivo malformado | baixe ou gere o JSON novamente |
+| `Cookie TOTVS ausente` | `--cookie` e `TOTVS_COOKIE` vazios | informe um cookie válido |
+| `Acesso a caminho fora do projeto não é permitido` | caminho com `../` ou absoluto externo | use caminho relativo dentro do repo |
+
+## Relacionados
+
+- [Instalação](INSTALLATION.md)
+- [Referência da API](API_REFERENCE.md)
+- [Solução de Problemas](TROUBLESHOOTING.md)

--- a/docs/guides/GOOGLE_CALENDAR.md
+++ b/docs/guides/GOOGLE_CALENDAR.md
@@ -1,45 +1,98 @@
-# Guia: Importar no Google Calendar
+# Importar no Google Calendar
 
-Este guia mostra a importação do arquivo `GoogleAgenda.csv` gerado pelo projeto.
+Use este guia para importar `GoogleAgenda.csv` no Google Calendar.
 
-## Pré-requisitos
+## Antes de Começar
 
-- arquivo `output/GoogleAgenda.csv` gerado com sucesso;
-- conta Google ativa;
-- acesso a <https://calendar.google.com>.
+Você precisa de:
 
-## Passo a passo
+- arquivo `GoogleAgenda.csv` gerado pela interface web ou pela CLI;
+- conta Google;
+- acesso a <https://calendar.google.com> pelo navegador.
 
-1. Abra o Google Calendar.
-2. No menu esquerdo, em **Outros calendários**, clique em **+**.
-3. Clique em **Importar**.
-4. Em **Selecionar arquivo do computador**, escolha `output/GoogleAgenda.csv`.
-5. Escolha o calendário de destino.
-6. Clique em **Importar**.
+Recomendação: crie um calendário dedicado para as aulas, por exemplo `Aulas CMMG`. Isso facilita apagar e reimportar sem misturar eventos pessoais.
+
+## Gerar o Arquivo
+
+Pela interface web:
+
+1. Acesse `/gerador`.
+2. Faça login no TOTVS, use cookie ou envie o JSON manualmente.
+3. Aguarde a análise.
+4. Clique em exportar CSV.
+
+Pela CLI:
+
+```bash
+npm run schedule:export -- --input data/QuadroHorarioAluno.json
+```
+
+Arquivo gerado:
+
+```text
+output/GoogleAgenda.csv
+```
+
+## Importação Passo a Passo
+
+1. Abra <https://calendar.google.com>.
+2. Clique na engrenagem.
+3. Acesse `Configurações`.
+4. No menu lateral, abra `Importar e exportar`.
+5. Em `Importar`, selecione `GoogleAgenda.csv`.
+6. Escolha o calendário de destino.
+7. Clique em `Importar`.
+8. Revise alguns eventos para confirmar data, horário e local.
+
+## Campos Exportados
+
+| Campo Google | Origem no JSON |
+| --- | --- |
+| Subject | `NOME` |
+| Start Date | `DATAINICIAL` |
+| Start Time | `HORAINICIAL` |
+| End Date | `DATAFINAL` ou `DATAINICIAL` |
+| End Time | `HORAFINAL` |
+| Description | `CODTURMA`, `CODSUBTURMA`, `NOMEREDUZIDO`, `URLAULAONLINE` |
+| Location | `PREDIO`, `BLOCO`, `SALA` |
 
 ## Recomendações
 
-- crie um calendário dedicado (ex.: `Aulas CMMG`);
-- ajuste o fuso para `America/Sao_Paulo`;
-- revise 2-3 eventos importados para confirmar horário/local.
+- Use fuso `America/Sao_Paulo`.
+- Importe primeiro em um calendário vazio.
+- Revise eventos de dias diferentes antes de confiar no calendário completo.
+- Guarde o CSV original até confirmar que a importação ficou correta.
 
-## Problemas comuns
+## Problemas Comuns
+
+### Eventos duplicados
+
+O Google pode duplicar eventos se você importar o mesmo CSV mais de uma vez. Para reimportar, prefira apagar o calendário dedicado e criar outro.
 
 ### Google rejeita o arquivo
 
-- confirme que o arquivo termina com `.csv`;
-- gere novamente pela interface web ou com `npm run schedule:export -- --input data/QuadroHorarioAluno.json`.
+Possíveis causas:
 
-### Datas/Horários incorretos
+- arquivo não termina em `.csv`;
+- arquivo foi editado por planilha e teve delimitadores alterados;
+- download foi interrompido.
 
-- confira o fuso da conta Google;
-- valide se `DATAINICIAL`, `HORAINICIAL` e `HORAFINAL` vieram corretos no JSON de origem.
+Correção: gere novamente o CSV pela interface ou pela CLI.
+
+### Datas ou horários incorretos
+
+Confira:
+
+- fuso do Google Calendar;
+- campos `DATAINICIAL`, `DATAFINAL`, `HORAINICIAL` e `HORAFINAL` no JSON original;
+- calendário de destino escolhido na importação.
 
 ### Eventos faltando
 
-- o exportador ignora entradas sem os campos mínimos (`NOME` e `DATAINICIAL`);
-- valide a qualidade do arquivo JSON.
+Entradas sem `NOME` ou sem `DATAINICIAL` são ignoradas. Se houver muitos eventos faltando, confira a qualidade do JSON exportado pelo portal.
 
-## Próximo passo
+## Relacionados
 
-- se preferir ICS, use o guia [THUNDERBIRD.md](THUNDERBIRD.md).
+- [Interface Web](WEB_INTERFACE.md)
+- [CLI](CLI.md)
+- [Thunderbird e iCalendar](THUNDERBIRD.md)

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,42 +1,69 @@
-# Guia de Instalação
+# Instalação e Ambiente Local
 
-Este guia cobre instalação e execução local do CMMG Calendar Analyzer.
+Este guia cobre o ambiente local do CMMG Calendar: instalação, execução, build, variáveis de ambiente e validação básica.
 
 ## Requisitos
 
-- Node.js `^20.19.0` ou `>=22.12.0`
-- npm 10+
-- Git
+| Ferramenta | Versão |
+| --- | --- |
+| Node.js | `^22.12.0` ou `>=24.0.0` |
+| npm | `>=10` |
+| Git | qualquer versão recente |
 
-## 1) Clone do projeto
+Valide antes de instalar:
+
+```bash
+node -v
+npm -v
+```
+
+## Instalação
 
 ```bash
 git clone https://github.com/bernardopg/cmmg-calendar.git
 cd cmmg-calendar
-```
-
-## 2) Instalação recomendada
-
-```bash
 npm install
 ```
 
-Isso instala dependências do `react-app/` e do `server/`.
+O `postinstall` da raiz executa `npm install` em `react-app/` e `server/`. Se precisar reinstalar manualmente:
 
-## 3) Execução local em dev/watch
+```bash
+npm run install:all
+```
 
-Fluxo recomendado:
+## Desenvolvimento Full Stack
 
 ```bash
 npm run dev
 ```
 
-Esse comando sobe:
+Esse comando sobe dois processos em paralelo:
 
-- backend Fastify em watch
-- frontend Vite em watch
+| Processo | Comando interno | URL padrão |
+| --- | --- | --- |
+| Backend | `npm run dev --prefix server` | `http://localhost:5000` |
+| Frontend | `npm run dev --prefix react-app` | `http://localhost:5173` |
 
-Se preferir abrir em terminais separados:
+Teste a API:
+
+```bash
+curl http://localhost:5000/api/health
+```
+
+Resposta esperada:
+
+```json
+{
+  "status": "up",
+  "message": "API funcionando",
+  "port": 5000,
+  "timestamp": "2026-06-16T14:32:28.691Z"
+}
+```
+
+## Processos Separados
+
+Use dois terminais quando quiser depurar um lado sem reiniciar o outro.
 
 Terminal 1:
 
@@ -50,72 +77,75 @@ Terminal 2:
 npm run dev:client
 ```
 
-Resultado esperado:
+## Proxy do Frontend
 
-- backend Fastify em `http://localhost:5000`
-- frontend Vite em `http://localhost:5173`
-- chamadas do browser indo para `/api/*`
-- proxy do Vite redirecionando `/api/*` para o Fastify local
+Em desenvolvimento, o frontend chama `/api/...`. O Vite encaminha essas chamadas para:
 
-## 4) Verificação
+```text
+VITE_API_PROXY_TARGET
+ou http://127.0.0.1:${SERVER_PORT || API_PORT || PORT || 5000}
+```
 
-Backend:
+Configurações úteis:
 
 ```bash
-curl http://localhost:5000/api/health
+VITE_PORT=5173 npm run dev:client
+SERVER_PORT=5001 npm run dev:client
+VITE_API_PROXY_TARGET=http://127.0.0.1:5001 npm run dev:client
 ```
 
-Retorno esperado:
-
-```json
-{"status":"up","message":"API funcionando","port":5000}
-```
-
-Frontend:
-
-- abra `http://localhost:5173`
-
-## 5) Build local e start de produção
+## Build Local
 
 ```bash
 npm run build
+```
+
+Saídas geradas:
+
+- `react-app/dist/`
+- `server/dist/`
+
+Para executar o app compilado:
+
+```bash
 npm start
 ```
 
-Esse fluxo sobe um único processo Node servindo:
+Nesse modo, o Fastify serve a API e a SPA compilada no mesmo processo.
 
-- `react-app/dist`
-- `/api/*`
-
-## 6) Utilitários CLI
-
-Analisar JSON:
+## Verificações de Qualidade
 
 ```bash
-npm run schedule:analyze -- --input data/QuadroHorarioAluno.json
+npm run lint
+npm run test
+npm run build
 ```
 
-Exportar CSV e ICS:
+Ou tudo de uma vez:
 
 ```bash
-npm run schedule:export -- --input data/QuadroHorarioAluno.json
+npm run check
 ```
 
-Buscar JSON no TOTVS via cookie:
+## Variáveis de Ambiente
 
-```bash
-npm run totvs:fetch -- --cookie 'ASP.NET_SessionId=...; .ASPXAUTH=...'
-```
+O backend carrega `.env` na raiz e depois `server/.env`. Valores em `server/.env` têm prioridade.
 
-## 7) Variáveis de ambiente opcionais
+Exemplo de `.env`:
 
-Crie `.env` na raiz:
-
-```bash
-PORT=5000
+```env
+NODE_ENV=development
 HOST=0.0.0.0
+PORT=5000
 MAX_FILE_SIZE_MB=10
 TOTVS_TIMEOUT_MS=30000
+TOTVS_BASE_URL=https://fundacaoeducacional132827.rm.cloudtotvs.com.br
+TOTVS_DEFAULT_ALIAS=CorporeRM
+```
+
+Variáveis TOTVS opcionais:
+
+```env
 TOTVS_COOKIE=
 TOTVS_QUADRO_URL=
 TOTVS_PORTAL_REFERER=
@@ -123,40 +153,60 @@ TOTVS_LOGIN_URL=
 TOTVS_AUTO_LOGIN_URL=
 TOTVS_CONTEXT_URL=
 TOTVS_CONTEXT_SELECTION_URL=
-TOTVS_DEFAULT_ALIAS=CorporeRM
 ```
 
-Opcionalmente, você pode criar `server/.env` para sobrescrever apenas variáveis do backend.
+Se essas URLs ficarem vazias, o backend usa os padrões derivados de `TOTVS_BASE_URL`.
 
-Para o Vite em desenvolvimento, as portas podem ser ajustadas com:
+Variáveis de CORS:
+
+```env
+CORS_ORIGINS=https://calendar.scalpel.com.br,https://outro-dominio.exemplo
+```
+
+Comportamento:
+
+- Em desenvolvimento sem `CORS_ORIGINS`, o backend reflete a origem para facilitar o uso com Vite.
+- Em produção sem `CORS_ORIGINS`, CORS cross-origin não é habilitado.
+
+## Docker
+
+Build local:
 
 ```bash
-VITE_PORT=5173
-SERVER_PORT=5000
+docker build -t cmmg-calendar .
 ```
 
-## Problemas comuns
+Execução:
 
-### `npm: command not found`
+```bash
+docker run -p 8080:8080 -e NODE_ENV=production cmmg-calendar
+```
 
-- instale Node.js + npm e valide com `node -v` e `npm -v`.
+Com variáveis extras:
 
-### Versão do Node incompatível
+```bash
+docker run \
+  -p 8080:8080 \
+  -e NODE_ENV=production \
+  -e PORT=8080 \
+  -e CORS_ORIGINS=https://calendar.scalpel.com.br \
+  cmmg-calendar
+```
 
-- use Node.js `20.19+` ou `22.12+`.
+## Deploy DigitalOcean
 
-### Porta 5000 ou 5173 já em uso
+O arquivo `.do/app.yaml` define:
 
-- ajuste `PORT`, `SERVER_PORT` ou `VITE_PORT` no ambiente antes de iniciar.
+- serviço `web`;
+- branch `main`;
+- `deploy_on_push: true`;
+- build via `Dockerfile`;
+- porta HTTP `8080`;
+- variáveis de runtime básicas.
 
-### `fetch('/api/...')` retorna erro no frontend
+## Próximos Passos
 
-- confirme que `npm run dev:server` está rodando
-- confirme que o proxy do Vite aponta para a porta certa
-- valide `curl http://localhost:5000/api/health`
-
-## 8) Próximos passos
-
-- UI: [WEB_INTERFACE.md](WEB_INTERFACE.md)
-- API: [API_REFERENCE.md](API_REFERENCE.md)
-- importação: [GOOGLE_CALENDAR.md](GOOGLE_CALENDAR.md) e [THUNDERBIRD.md](THUNDERBIRD.md)
+- [Interface Web](WEB_INTERFACE.md)
+- [Referência da API](API_REFERENCE.md)
+- [CLI](CLI.md)
+- [Solução de Problemas](TROUBLESHOOTING.md)

--- a/docs/guides/MIGRATION_STATUS.md
+++ b/docs/guides/MIGRATION_STATUS.md
@@ -1,19 +1,32 @@
 # Status da Migração
 
-A migração de Flask/Python para Node.js foi concluída.
+A migração do backend Flask/Python para Node.js foi concluída. Este arquivo permanece como registro histórico para evitar dúvidas sobre qual stack é canônica.
 
-## Estado atual
+## Estado Atual
 
-- backend principal em `server/` com Fastify + TypeScript
-- rotas `/api/health`, `/api/analyze`, `/api/extract-analyze` e `/api/totvs-login`
-- fluxo local com `npm run dev`, `npm run dev:server` e `npm run dev:client`
-- build único com frontend em `react-app/dist` e backend em `server/dist`
-- utilitários CLI Node para análise, exportação e fetch via cookie
-- testes automatizados do backend Node em `server/src/*.test.ts`
-- CI baseada apenas em Node.js
+| Área | Status |
+| --- | --- |
+| Backend canônico | `server/` com Fastify + TypeScript |
+| Frontend canônico | `react-app/` com React + Vite + TypeScript |
+| API ativa | `/api/health`, `/api/analyze`, `/api/extract-analyze`, `/api/totvs-login` |
+| CLI ativa | comandos Node em `server/src/cli/` |
+| Testes ativos | Node Test Runner em `server/src/**/*.test.ts` |
+| CI ativa | GitHub Actions com Node 24 |
+| Deploy principal | Docker Node 24 no DigitalOcean App Platform |
 
-## Resultado
+## O Que Não É Mais Canônico
 
-- o projeto não depende mais de Python
-- o deploy principal pode ser feito integralmente com Node.js
-- a interface web, a API e os utilitários locais estão concentrados no stack atual
+- Backend Python/Flask.
+- Dependências Python para execução principal.
+- Scripts antigos de migração como fonte de verdade.
+
+## Onde Consultar a Fonte de Verdade
+
+- [Manual do Projeto](../../DOCUMENTACAO.md)
+- [Arquitetura](ARCHITECTURE.md)
+- [Instalação](INSTALLATION.md)
+- [Referência da API](API_REFERENCE.md)
+
+## Implicação Para Novas Mudanças
+
+Novas features, correções e documentação devem considerar `server/` e `react-app/` como base. Se algum documento ou comentário mencionar Flask/Python como runtime atual, trate como informação desatualizada.

--- a/docs/guides/THUNDERBIRD.md
+++ b/docs/guides/THUNDERBIRD.md
@@ -1,51 +1,102 @@
-# Guia: Importar no Thunderbird
+# Importar ICS no Thunderbird e Outros Calendários
 
-Este guia mostra a importação do arquivo `ThunderbirdAgenda.ics` gerado pelo projeto.
+Use este guia para importar `ThunderbirdAgenda.ics`. O formato ICS é compatível com Thunderbird, Outlook, Apple Calendar, Google Calendar e vários clientes de calendário.
 
-## Pré-requisitos
+## Antes de Começar
 
-- arquivo `output/ThunderbirdAgenda.ics` gerado com sucesso;
-- Mozilla Thunderbird instalado.
+Você precisa de:
 
-## Método recomendado (menu)
+- arquivo `ThunderbirdAgenda.ics` gerado pela interface web ou pela CLI;
+- Thunderbird ou outro app compatível com iCalendar;
+- calendário de destino criado, preferencialmente separado para as aulas.
+
+## Gerar o Arquivo
+
+Pela interface web:
+
+1. Acesse `/gerador`.
+2. Faça login no TOTVS, use cookie ou envie o JSON manualmente.
+3. Aguarde a análise.
+4. Clique em exportar ICS.
+
+Pela CLI:
+
+```bash
+npm run schedule:export -- --input data/QuadroHorarioAluno.json
+```
+
+Arquivo gerado:
+
+```text
+output/ThunderbirdAgenda.ics
+```
+
+## Importar no Thunderbird
 
 1. Abra o Thunderbird.
-2. Vá para a aba de calendário.
-3. Clique em **Arquivo > Importar**.
-4. Selecione **Calendário**.
-5. Escolha o arquivo `output/ThunderbirdAgenda.ics`.
-6. Defina o calendário de destino.
+2. Acesse a área de calendário.
+3. Selecione `Arquivo > Importar`.
+4. Escolha a opção de calendário.
+5. Selecione `ThunderbirdAgenda.ics`.
+6. Escolha o calendário de destino.
 7. Conclua a importação.
+8. Revise alguns eventos.
 
-## Método alternativo (arrastar e soltar)
+Alternativa: arraste o arquivo `.ics` para a área de calendário e confirme a importação.
 
-1. Abra a aba calendário no Thunderbird.
-2. Arraste `output/ThunderbirdAgenda.ics` para dentro da interface.
-3. Confirme o calendário de destino.
+## Importar em Outros Apps
+
+| App | Caminho comum |
+| --- | --- |
+| Outlook | `Arquivo > Abrir e Exportar > Importar/Exportar` |
+| Apple Calendar | `Arquivo > Importar` |
+| Google Calendar | `Configurações > Importar e exportar` |
+
+Os nomes dos menus podem variar conforme versão e sistema operacional.
+
+## Campos Exportados
+
+| Campo ICS | Origem |
+| --- | --- |
+| `UID` | ID único gerado no momento da exportação |
+| `DTSTAMP` | data/hora da geração do arquivo |
+| `DTSTART` | `DATAINICIAL` + `HORAINICIAL` |
+| `DTEND` | `DATAFINAL` ou `DATAINICIAL` + `HORAFINAL` |
+| `SUMMARY` | `NOME` |
+| `DESCRIPTION` | turma, subturma, código e aula online |
+| `LOCATION` | prédio, bloco e sala |
 
 ## Recomendações
 
-- use o fuso `America/Sao_Paulo`;
-- crie um calendário dedicado (ex.: `Aulas CMMG`);
-- revise alguns eventos após importar.
+- Use fuso `America/Sao_Paulo` no calendário de destino.
+- Importe em calendário dedicado para facilitar reimportações.
+- Revise eventos em semanas diferentes após importar.
+- Se precisar compartilhar o horário com outro app, prefira ICS.
 
-## Problemas comuns
+## Problemas Comuns
 
-### Arquivo não abre/importa
+### Arquivo não importa
 
-- confira extensão `.ics`;
-- gere novamente pela interface web ou com `npm run schedule:export -- --input data/QuadroHorarioAluno.json`.
+Correções:
 
-### Eventos com horário incorreto
+- confirme que o arquivo termina em `.ics`;
+- gere o arquivo novamente;
+- teste importar em um calendário vazio.
 
-- valide o fuso no Thunderbird;
-- confira os horários no JSON de origem.
+### Horário deslocado
+
+Correções:
+
+- confira fuso do app;
+- confirme horários no JSON original;
+- revise se o app interpreta eventos sem timezone explícito de forma diferente.
 
 ### Eventos faltando
 
-- entradas sem campos mínimos podem ser ignoradas no exportador;
-- valide os dados de entrada.
+O exportador ignora entradas sem `NOME`, `DATAINICIAL`, `HORAINICIAL` ou `HORAFINAL`, e também ignora datas inválidas.
 
-## Próximo passo
+## Relacionados
 
-- se quiser usar Google Calendar, veja [GOOGLE_CALENDAR.md](GOOGLE_CALENDAR.md).
+- [Interface Web](WEB_INTERFACE.md)
+- [CLI](CLI.md)
+- [Google Calendar](GOOGLE_CALENDAR.md)

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,0 +1,195 @@
+# Solução de Problemas
+
+Este guia reúne problemas frequentes em desenvolvimento, uso da interface, integração TOTVS, exportação e deploy.
+
+## Instalação
+
+### Versão do Node incompatível
+
+Sintoma:
+
+```text
+Unsupported engine
+```
+
+Correção:
+
+```bash
+node -v
+```
+
+Use Node.js `^22.12.0` ou `>=24.0.0`.
+
+### Dependências inconsistentes
+
+Sintoma:
+
+- erros estranhos após atualização de branch;
+- pacote não encontrado;
+- lockfile fora de sincronia.
+
+Correção:
+
+```bash
+npm install
+npm run install:all
+```
+
+Se for ambiente de CI ou build limpo, use `npm ci` nos pacotes relevantes.
+
+## Desenvolvimento Local
+
+### Porta 5000 ou 5173 em uso
+
+Correção rápida:
+
+```bash
+PORT=5001 npm run dev:server
+SERVER_PORT=5001 npm run dev:client
+```
+
+Ou configure:
+
+```bash
+VITE_PORT=5174 npm run dev:client
+```
+
+### Frontend não conecta na API
+
+Checklist:
+
+- backend está rodando com `npm run dev:server`;
+- `curl http://localhost:5000/api/health` responde;
+- Vite está usando a porta correta em `SERVER_PORT`, `API_PORT`, `PORT` ou `VITE_API_PROXY_TARGET`;
+- chamadas do frontend usam caminho relativo `/api/...`.
+
+## Upload e Análise
+
+### Arquivo rejeitado
+
+Causas comuns:
+
+- arquivo não termina com `.json`;
+- JSON malformado;
+- payload não contém `data.SHorarioAluno`;
+- arquivo excede `MAX_FILE_SIZE_MB`.
+
+Correções:
+
+- baixe novamente o arquivo do portal;
+- valide se o JSON abre em um editor;
+- aumente `MAX_FILE_SIZE_MB` apenas se realmente necessário.
+
+### Estatísticas mostram muitos inválidos
+
+O analisador considera registro válido quando há pelo menos `NOME` e `DATAINICIAL`. Registros sem esses campos entram em `invalid_entries`.
+
+## TOTVS
+
+### Login retorna `401`
+
+Causas comuns:
+
+- usuário ou senha incorretos;
+- portal exige fluxo adicional não coberto;
+- alias/contexto incompatível.
+
+Correções:
+
+- teste login diretamente no Portal do Aluno;
+- tente informar `alias` no body de `/api/totvs-login`;
+- confira `TOTVS_DEFAULT_ALIAS`.
+
+### Cookie retorna `401`
+
+Causas comuns:
+
+- cookie expirado;
+- cookie copiado incompleto;
+- sessão pertence a outro contexto.
+
+Correção:
+
+- faça login novamente no portal e copie o header `Cookie` completo.
+
+### Erro `502` ao consultar TOTVS
+
+Causas comuns:
+
+- portal indisponível;
+- timeout;
+- endpoint TOTVS alterado;
+- resposta não veio em JSON.
+
+Correções:
+
+- tente novamente depois;
+- aumente `TOTVS_TIMEOUT_MS` temporariamente;
+- confirme `TOTVS_BASE_URL` e URLs específicas se foram sobrescritas.
+
+## Exportação e Importação
+
+### Google Calendar rejeita CSV
+
+Correções:
+
+- gere novamente `GoogleAgenda.csv`;
+- importe pelo Google Calendar no navegador;
+- confirme que o arquivo não foi aberto e salvo por editor que altere delimitadores.
+
+### Eventos aparecem duplicados
+
+O CMMG Calendar não remove eventos antigos do seu calendário. Crie um calendário dedicado para as aulas e apague-o antes de reimportar.
+
+### Horários parecem deslocados
+
+Correções:
+
+- confira o fuso do calendário de destino;
+- use `America/Sao_Paulo`;
+- confira `HORAINICIAL` e `HORAFINAL` no JSON original.
+
+## Build e Deploy
+
+### `npm run build` falha no frontend
+
+Execute os checks específicos:
+
+```bash
+npm run lint --prefix react-app
+npm exec --prefix react-app -- tsc --noEmit
+npm run build --prefix react-app
+```
+
+Observação: se usar `npx tsc`, execute dentro de `react-app` ou use o script do CI como referência.
+
+### `npm run build` falha no backend
+
+```bash
+npm run test --prefix server
+npm run build --prefix server
+```
+
+### Produção mostra `Frontend build não encontrado`
+
+Causa: `react-app/dist` não existe no ambiente que iniciou o Fastify.
+
+Correção:
+
+```bash
+npm run build
+npm start
+```
+
+No Dockerfile, isso é feito automaticamente no estágio `builder`.
+
+## Antes de Abrir Issue
+
+Cole no relatório:
+
+- comando executado;
+- versão de Node e npm;
+- ambiente (`dev`, Docker, produção);
+- mensagem de erro completa;
+- endpoint chamado, se for API;
+- se envolve TOTVS, informe se login direto no portal funciona, mas nunca cole senha ou cookie público.

--- a/docs/guides/WEB_INTERFACE.md
+++ b/docs/guides/WEB_INTERFACE.md
@@ -1,105 +1,139 @@
-# Guia da Interface Web
+# Interface Web
 
-Este guia explica os fluxos de uso da aplicação web em `react-app/`, integrada ao backend Fastify em `server/`.
+A interface web é a forma recomendada de uso para estudantes. Ela oferece três caminhos para obter os horários, mostra uma análise do semestre e gera os arquivos de calendário direto no navegador.
 
-## Pré-requisitos
+## Acesso
 
-- API ativa em `http://localhost:5000`
-- frontend ativo em `http://localhost:5173`
+Produção:
 
-Início rápido:
+- <https://calendar.scalpel.com.br>
+
+Desenvolvimento local:
 
 ```bash
 npm run dev
 ```
 
-Ou, em dois terminais:
+URLs locais:
+
+- `http://localhost:5173`: SPA React/Vite
+- `http://localhost:5000/api/health`: API Fastify
+
+## Rotas da Aplicação
+
+| Rota | Finalidade |
+| --- | --- |
+| `/` | Página inicial e apresentação do produto. |
+| `/gerador` | Gerador de calendário: login, cookie, upload, análise e exportação. |
+| `/guia` | Guia de uso dentro da aplicação. |
+| `/faq` | Perguntas frequentes. |
+| `/sobre` | Contexto do projeto e tecnologias. |
+
+## Fluxo Recomendado: Login TOTVS
+
+1. Abra `/gerador`.
+2. Informe usuário e senha do Portal do Aluno.
+3. Clique em `Entrar e Extrair Horário`.
+4. Aguarde a análise.
+5. Revise as estatísticas.
+6. Exporte CSV ou ICS.
+
+Privacidade: a senha é enviada ao backend apenas para autenticar no TOTVS durante a requisição. Ela não é armazenada pela aplicação.
+
+## Fluxo Avançado: Cookie Manual
+
+Use quando o login automático falhar ou quando você já tiver uma sessão autenticada no portal.
+
+1. Entre no Portal do Aluno pelo navegador.
+2. Copie o header `Cookie` da sessão autenticada.
+3. Em `/gerador`, abra `Opções avançadas (cookie manual)`.
+4. Cole o cookie.
+5. Clique em `Extrair via Cookie`.
+
+O cookie precisa conter uma sessão válida do TOTVS, normalmente com valores como `ASP.NET_SessionId` e `.ASPXAUTH`.
+
+## Fluxo Manual: Upload JSON
+
+Use quando você já tiver baixado o arquivo `QuadroHorarioAluno.json`.
+
+1. Abra `/gerador`.
+2. Arraste o arquivo para a área de upload ou clique para selecionar.
+3. Confirme que o arquivo foi reconhecido.
+4. Clique em `Analisar horário`.
+5. Exporte CSV ou ICS.
+
+O frontend valida se o JSON possui o formato mínimo `data.SHorarioAluno` antes de usar os dados para exportação.
+
+## O Que A Análise Mostra
+
+- total de registros encontrados;
+- registros válidos e inválidos;
+- disciplinas mais frequentes;
+- horários mais comuns;
+- locais mais usados;
+- distribuição por dia da semana;
+- distribuição mensal;
+- prévia de eventos do calendário.
+
+## Exportação
+
+| Botão | Arquivo | Melhor para |
+| --- | --- | --- |
+| Exportar CSV | `GoogleAgenda.csv` | Google Calendar |
+| Exportar ICS | `ThunderbirdAgenda.ics` | Thunderbird, Outlook, Apple Calendar e outros |
+
+A exportação da UI é client-side. Isso significa que, depois que os dados estão carregados no navegador, o arquivo é gerado localmente sem uma segunda chamada à API.
+
+## Estados e Erros Comuns
+
+### API offline
+
+Sintomas:
+
+- indicador da API aparece offline;
+- chamadas para `/api/...` falham.
+
+Ações:
 
 ```bash
 npm run dev:server
-npm run dev:client
+curl http://localhost:5000/api/health
 ```
 
-## Fluxos disponíveis
+### Arquivo inválido
 
-### 1) Login no Portal do Aluno
+Sintomas:
 
-Use usuário e senha do TOTVS para que o backend faça login, consulte o `QuadroHorarioAluno` e devolva a análise pronta.
+- upload não gera dados;
+- API retorna erro de JSON inválido ou estrutura inesperada.
 
-### 2) Cookie manual
+Ações:
 
-Cole o header `Cookie` de uma sessão já autenticada no portal. Esse fluxo usa o endpoint `/extract-analyze`.
+- confirme que o arquivo termina em `.json`;
+- confirme que existe `data.SHorarioAluno`;
+- baixe novamente o arquivo no portal.
 
-### 3) Upload manual
+### Login TOTVS falha
 
-Envie o `QuadroHorarioAluno.json` diretamente pela interface. Esse fluxo usa o endpoint `/analyze`.
+Sintomas:
 
-## Fluxo de uso
+- mensagem de credenciais inválidas;
+- erro de conexão com TOTVS;
+- resposta do portal não vem em JSON esperado.
 
-1. Abra `http://localhost:5173`
-2. Escolha login, cookie manual ou upload
-3. Aguarde a análise
-4. Revise os painéis de estatísticas
-5. Exporte CSV ou ICS
+Ações:
 
-## O que a interface mostra
+- teste login diretamente no Portal do Aluno;
+- tente novamente depois se o portal estiver instável;
+- use cookie manual como alternativa;
+- confira se variáveis `TOTVS_*` foram sobrescritas corretamente.
 
-- status da API
-- feedback de upload, autenticação e análise
-- métricas de total, validade e distribuição de registros
-- ações de exportação
+### Eventos duplicados no calendário
 
-## Mensagens de erro comuns
+Isso acontece no app de calendário, não no CMMG Calendar. Para evitar duplicação, importe em um calendário dedicado e apague esse calendário antes de reimportar.
 
-### Erro de conexão
+## Links Úteis
 
-Causa provável:
-
-- API não iniciada
-- proxy do Vite não apontando para a porta correta
-
-Ação:
-
-```bash
-npm run dev:server
-```
-
-### Erro ao analisar arquivo
-
-Causa provável:
-
-- arquivo fora do formato esperado
-- JSON inválido
-- chave `SHorarioAluno` ausente dentro de `data`
-
-Ação:
-
-- valide a estrutura do arquivo e tente novamente
-
-### Erro no login TOTVS
-
-Causa provável:
-
-- credenciais inválidas
-- portal indisponível
-- sessão expirada
-
-Ação:
-
-- tente novamente com credenciais válidas ou use o fluxo por cookie
-
-## Ambiente de desenvolvimento
-
-Backend:
-
-```bash
-npm run dev:server
-```
-
-Frontend:
-
-```bash
-npm run dev:client
-```
-
-A aplicação usa `fetch('/api/...')` e o Vite faz proxy de `/api` para o backend local.
+- [Google Calendar](GOOGLE_CALENDAR.md)
+- [Thunderbird e iCalendar](THUNDERBIRD.md)
+- [Solução de Problemas](TROUBLESHOOTING.md)

--- a/react-app/src/pages/FaqPage.tsx
+++ b/react-app/src/pages/FaqPage.tsx
@@ -115,7 +115,7 @@ const faqGeneral = [
   {
     question: 'Onde encontro o arquivo QuadroHorarioAluno.json?',
     answer:
-      'O arquivo é gerado pelo portal acadêmico do CMMG. Acesse o portal, vá até a seção de horários e exporte/salve o arquivo JSON.',
+      'O arquivo é gerado pelo portal acadêmico do CMMG. Você pode baixá-lo manualmente no portal ou usar o login automático da aplicação para buscar os dados sem fazer download prévio.',
   },
   {
     question: 'Preciso criar uma conta para usar?',
@@ -161,7 +161,7 @@ const faqPrivacy = [
   {
     question: 'Meus dados ficam armazenados?',
     answer:
-      'Não. O arquivo é enviado para a API apenas para processamento. Nenhum dado é salvo no servidor após a resposta.',
+      'Não. Arquivos, cookies e credenciais TOTVS são usados apenas durante a requisição necessária para analisar o horário. A aplicação não persiste esses dados.',
   },
   {
     question: 'O que acontece se o arquivo estiver com erro?',
@@ -171,6 +171,6 @@ const faqPrivacy = [
   {
     question: 'A ferramenta acessa minha conta do portal?',
     answer:
-      'Não. A ferramenta apenas processa o arquivo JSON que você já exportou do portal. Nenhuma credencial é solicitada ou acessada.',
+      'Somente se você escolher o fluxo de login automático. Nesse caso, suas credenciais são enviadas ao backend para autenticar no TOTVS e buscar o horário, sem armazenamento. Se preferir, use cookie manual ou upload do JSON.',
   },
 ];

--- a/react-app/src/pages/GuidePage.tsx
+++ b/react-app/src/pages/GuidePage.tsx
@@ -31,7 +31,7 @@ export const GuidePage = () => {
       {/* Quick Steps */}
       <section className="guide-section fade-up">
         <h2 className="guide-section__title">Como funciona</h2>
-        <p className="guide-section__desc">Três passos simples para organizar seu semestre.</p>
+        <p className="guide-section__desc">Use login TOTVS, cookie manual ou upload do JSON para organizar seu semestre.</p>
 
         <div className="guide-steps">
           <div className="guide-step surface-card card-hover">
@@ -39,8 +39,8 @@ export const GuidePage = () => {
             <div className="guide-step__icon">
               <FileJson size={24} />
             </div>
-            <h3>Obtenha o JSON</h3>
-            <p>Exporte o arquivo <code>QuadroHorarioAluno.json</code> no portal acadêmico.</p>
+            <h3>Obtenha os dados</h3>
+            <p>Entre com o login do Portal do Aluno, use cookie manual ou selecione o <code>QuadroHorarioAluno.json</code>.</p>
           </div>
 
           <div className="guide-steps__arrow">
@@ -52,8 +52,8 @@ export const GuidePage = () => {
             <div className="guide-step__icon">
               <Upload size={24} />
             </div>
-            <h3>Faça o upload</h3>
-            <p>Arraste o arquivo ou clique para selecioná-lo na página do gerador.</p>
+            <h3>Analise o horário</h3>
+            <p>A aplicação valida os dados e mostra estatísticas de disciplinas, dias, horários e locais.</p>
           </div>
 
           <div className="guide-steps__arrow">
@@ -82,16 +82,16 @@ export const GuidePage = () => {
                 <FileJson size={20} />
               </div>
               <div>
-                <h3>1. Obtendo o arquivo JSON</h3>
-                <p>Acesse o portal acadêmico do CMMG</p>
+                <h3>1. Obtendo os dados do horário</h3>
+                <p>Escolha o método mais conveniente</p>
               </div>
             </div>
             <div className="guide-detail-card__body">
               <ol className="guide-ol">
-                <li>Acesse o <strong>portal acadêmico</strong> com seu login e senha.</li>
-                <li>Navegue até a seção de <strong>Quadro de Horários</strong>.</li>
-                <li>O portal gera um arquivo chamado <code>QuadroHorarioAluno.json</code>.</li>
-                <li>Salve o arquivo no seu computador ou celular.</li>
+                <li>Use <strong>login automático</strong> com as credenciais do Portal do Aluno.</li>
+                <li>Ou use <strong>cookie manual</strong> se já tiver uma sessão TOTVS autenticada.</li>
+                <li>Ou faça upload do arquivo <code>QuadroHorarioAluno.json</code> baixado do portal.</li>
+                <li>Em qualquer fluxo, os dados são analisados antes da exportação.</li>
               </ol>
               <div className="guide-tip">
                 <Zap size={16} />
@@ -112,14 +112,14 @@ export const GuidePage = () => {
             </div>
             <div className="guide-detail-card__body">
               <ol className="guide-ol">
-                <li>Vá até o <Link to="/gerador"><strong>Gerador de Calendário</strong></Link> ou <Link to="/analisador"><strong>Analisador</strong></Link>.</li>
-                <li><strong>Arraste o arquivo</strong> para a área tracejada ou clique para selecionar.</li>
-                <li>Confira se o nome do arquivo aparece confirmado.</li>
-                <li>Clique em <strong>"Analisar horário"</strong> para processar.</li>
+                <li>Vá até o <Link to="/gerador"><strong>Gerador de Calendário</strong></Link>.</li>
+                <li>Preencha login e senha, cole um cookie ou selecione o arquivo JSON.</li>
+                <li>Confira se a análise retornou os dados esperados.</li>
+                <li>Revise as estatísticas antes de exportar.</li>
               </ol>
               <div className="guide-tip">
                 <ShieldCheck size={16} />
-                <span><strong>Privacidade:</strong> O arquivo é processado apenas para gerar o resultado. Nenhum dado é armazenado.</span>
+                <span><strong>Privacidade:</strong> credenciais, cookies e arquivos são usados apenas para processar a requisição. Nenhum dado é armazenado pela aplicação.</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Resumo
- Reorganiza README, manual central e índice de documentação
- Atualiza guias de instalação, API, interface, importação, migração, governança e segurança
- Adiciona guias de arquitetura, CLI e troubleshooting
- Corrige textos da UI em /guia e /faq para refletir os fluxos reais de login, cookie e upload

## Validação
- npm run lint --prefix react-app
- npm run build --prefix react-app
- npm run build --prefix server
- validação local de links Markdown (23 arquivos)